### PR TITLE
GoDoc: Add missing help output, fix formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.2.1] - 2019-12-19
+
+### Fixed
+
+- Add missing flag in help output
+- Remove forced line break/wrapping since GoDoc interprets
+  this as a code block instead of continuing the line
+
 ## [v0.2.0] - 2019-12-19
 
 ### Added
@@ -44,6 +52,7 @@ This initial prototype supports/provides:
 - GitHub Actions linting and build checks
 - Makefile for general use cases
 
-[Unreleased]: https://github.com/atc0005/send2teams/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/atc0005/send2teams/compare/v0.2.1...HEAD
+[v0.2.1]: https://github.com/atc0005/send2teams/releases/tag/v0.2.1
 [v0.2.0]: https://github.com/atc0005/send2teams/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/atc0005/send2teams/releases/tag/v0.1.0

--- a/doc.go
+++ b/doc.go
@@ -21,8 +21,7 @@ FEATURES
 
 • very few build dependencies
 
-• optional conversion of messages with Windows, Mac or Linux newlines to
-  `<br>` to increase compatibility with Teams formatting
+• optional conversion of messages with Windows, Mac or Linux newlines to `<br>` to increase compatibility with Teams formatting
 
 USAGE
 
@@ -33,6 +32,8 @@ Help output is below. See the README for examples.
 			The target channel where we will send a message
 	-color string
 			The hex color code used to set the desired trim color on submitted messages (default "#832561")
+	-convert-eol
+			Whether messages with Windows, Mac and Linux newlines are updated to use break statements before message submission
 	-message string
 			The (optionally) Markdown-formatted message to submit
 	-silent


### PR DESCRIPTION
- Add missing flag in help output
- Remove forced line break/wrapping since GoDoc interprets
  this as a code block instead of continuing the line

fixes #4
