### PR TITLE
Extend webhook URL validation to match valid FQDNs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/atc0005/send2teams
 
 require (
+	//gopkg.in/dasrick/go-teams-notify.v1 v1.2.0
+
+	// temporarily use our fork until upstream webhook URL FQDN validation
+	// changes can be made
+	github.com/atc0005/go-teams-notify v1.2.1-0.20200324114153-d5bf5e1bebf3
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
-	gopkg.in/dasrick/go-teams-notify.v1 v1.2.0
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atc0005/go-teams-notify v1.2.1-0.20200324114153-d5bf5e1bebf3 h1:LnpGj5K/8+Le8vCTyBHCIaW9FNXLwQuYH9DLhNfOL4k=
+github.com/atc0005/go-teams-notify v1.2.1-0.20200324114153-d5bf5e1bebf3/go.mod h1:ZpgVtOijRLmHoJrp2DYvDv/lLcfIt2jvHlyOI92N/Gs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -9,8 +11,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/dasrick/go-teams-notify.v1 v1.2.0 h1:PxzBpuujW+8OpNnc85KGtPgjhf5irwLvCCGBrpvyfL8=
-gopkg.in/dasrick/go-teams-notify.v1 v1.2.0/go.mod h1:r4+HvPngQrMDDcpAJwpTk82CA/wbIad/TTZC3vOFhNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=


### PR DESCRIPTION
## Changes

- Update webhook URL validation checks
  - allow either of the known valid webhook URL FQDNs
    - outlook.office.com
    - outlook.office365.com
  - webhook URL length check to fail early with (hopefully) a useful error message
  - full regex pattern check in an effort to help catch poorly formatted webhook URLs

- Switch go-teams-notify package source to our fork in order to allow both valid webhook URL FQDNs
  - upstream currently only allows the (apparently) more common outlook.office.com FQDN
  - an issue has been filed with upstream to extend the `isValidWebhookURL()` validation function so that a fork is not necessary

## References

refs #18, #12

fixes #20