### PR TITLE
Update daskrick/go-teams-notify package to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/atc0005/send2teams
 require (
 	//gopkg.in/dasrick/go-teams-notify.v1 v1.2.0
 
-	// temporarily use our fork until upstream webhook URL FQDN validation
-	// changes can be made
-	github.com/atc0005/go-teams-notify v1.2.1-0.20200324114153-d5bf5e1bebf3
+	// temporarily use our fork while developing changes for potential
+	// inclusion in the upstream project
+	github.com/atc0005/go-teams-notify v1.3.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify v1.2.1-0.20200324114153-d5bf5e1bebf3 h1:LnpGj5K/8+Le8vCTyBHCIaW9FNXLwQuYH9DLhNfOL4k=
-github.com/atc0005/go-teams-notify v1.2.1-0.20200324114153-d5bf5e1bebf3/go.mod h1:ZpgVtOijRLmHoJrp2DYvDv/lLcfIt2jvHlyOI92N/Gs=
+github.com/atc0005/go-teams-notify v1.3.0 h1:BPmEyxgv+W7LLUtHgSbvCyruCrY0aRqixQbKzFqOY+E=
+github.com/atc0005/go-teams-notify v1.3.0/go.mod h1:ZpgVtOijRLmHoJrp2DYvDv/lLcfIt2jvHlyOI92N/Gs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -19,8 +19,8 @@ import (
 
 	//goteamsnotify "gopkg.in/dasrick/go-teams-notify.v1"
 
-	// temporarily use our fork until upstream webhook URL FQDN validation
-	// changes can be made
+	// temporarily use our fork while developing changes for potential
+	// inclusion in the upstream project
 	goteamsnotify "github.com/atc0005/go-teams-notify"
 )
 


### PR DESCRIPTION
This release incorporates changes to allow either of
these webook URL FQDNs:

- outlook.office.com
- outlook.office365.com

For now, we're still referencing our fork instead of upstream
since I'm actively testing further changes for potential
inclusion in the upstream dasrick/go-teams-notify project.

fixes #23