### PR TITLE
Export golangci-lint options, add scopelint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/send2teams
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+linters:
+  enable:
+    - dogsled
+    - goimports
+    - gosec
+    - stylecheck
+    - goconst
+    - depguard
+    - prealloc
+    - misspell
+    - maligned
+    - dupl
+    - unconvert
+    - golint
+    - gocritic
+    - scopelint

--- a/Makefile
+++ b/Makefile
@@ -85,20 +85,8 @@ linting:
 	@echo "Running golint ..."
 	@golint -set_exit_status ./...
 
-	@echo "Running golangci-lint ..."
-	@golangci-lint run \
-		-E goimports \
-		-E gosec \
-		-E stylecheck \
-		-E goconst \
-		-E depguard \
-		-E prealloc \
-		-E misspell \
-		-E maligned \
-		-E dupl \
-		-E unconvert \
-		-E golint \
-		-E gocritic
+	@echo "Running golangci-lint using settings from .golangci.yml ..."
+	@golangci-lint run
 
 	@echo "Running staticcheck ..."
 	@staticcheck ./...


### PR DESCRIPTION
## Summary

- Move linter choices from Makefile to separate include file

- Add scopelint linter to help catch variable use
  outside of intended scope

## References

- fixes #42
- fixes #44
- refs atc0005/todo#4
- refs dasrick/go-teams-notify#14