### PR TITLE
Minor spacing tweak, add/update copyright year

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019 Adam Chalkley
+# Copyright 2020 Adam Chalkley
 #
 # https://github.com/atc0005/send2teams
 #

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019 Adam Chalkley
+# Copyright 2020 Adam Chalkley
 #
 # https://github.com/atc0005/send2teams
 #

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2019 Adam Chalkley
+# Copyright 2020 Adam Chalkley
 #
 # https://github.com/atc0005/send2teams
 #

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 Adam Chalkley
+# Copyright 2020 Adam Chalkley
 #
 # https://github.com/atc0005/send2teams
 #

--- a/cmd/send2teams/main.go
+++ b/cmd/send2teams/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Adam Chalkley
+// Copyright 2020 Adam Chalkley
 //
 // https://github.com/atc0005/send2teams
 //

--- a/doc.go
+++ b/doc.go
@@ -32,7 +32,7 @@ FEATURES
 
 • exported `teams` package to handle formatting text content as code for proper display within Microsoft Teams
 
-•  message delivery retry support with retry and retry delay values configurable via flag
+• message delivery retry support with retry and retry delay values configurable via flag
 
 
 USAGE

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/send2teams
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
 module github.com/atc0005/send2teams
 
 require (

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -1,3 +1,10 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/send2teams
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
 package config
 
 import "flag"

--- a/teams/teams.go
+++ b/teams/teams.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Adam Chalkley
+// Copyright 2020 Adam Chalkley
 //
 // https://github.com/atc0005/send2teams
 //


### PR DESCRIPTION
- Add copyright header where it was not present
- Update 2019 to 2020 due to recent spread of updates
