### PR TITLE
Remove validation func merged upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 	// temporarily use our fork while developing changes for potential
 	// inclusion in the upstream project
-	github.com/atc0005/go-teams-notify v1.3.1-0.20200409143202-ebfbb4503f85
+	github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify v1.3.1-0.20200409143202-ebfbb4503f85 h1:Af+UL6i0llGOUAeD8iKvOCkYQmpHl3rcEletiT3UCyY=
-github.com/atc0005/go-teams-notify v1.3.1-0.20200409143202-ebfbb4503f85/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
+github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e h1:zRyZGkOWTLymKTp96PmPaOO1KIAtS0YBvAeTIKEodNs=
+github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/teams/teams.go
+++ b/teams/teams.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -319,41 +318,6 @@ func validateWebhookLength(webhookURL string) error {
 	return nil
 }
 
-// validateWebhookURLPrefix ensure that known/expected prefixes are used with
-// provided webhook URL
-func validateWebhookURLPrefix(webhookURL string) error {
-
-	// TODO: Inquire about merging this upstream
-	// Reasons:
-	//
-	// Move urls to constants for easier, less error-prone references
-	// User-friendly error messages
-	//
-	switch {
-	case strings.HasPrefix(webhookURL, webhookURLOfficecomPrefix):
-	case strings.HasPrefix(webhookURL, webhookURLOffice365Prefix):
-	default:
-		u, err := url.Parse(webhookURL)
-		if err != nil {
-			return fmt.Errorf(
-				"unable to parse webhook URL %q: %v",
-				webhookURL,
-				err,
-			)
-		}
-		userProvidedWebhookURLPrefix := u.Scheme + "://" + u.Host
-
-		return fmt.Errorf(
-			"webhook URL does not contain expected prefix; got %q, expected one of %q or %q",
-			userProvidedWebhookURLPrefix,
-			webhookURLOfficecomPrefix,
-			webhookURLOffice365Prefix,
-		)
-	}
-
-	return nil
-}
-
 // validateWebhookURLRegex applies a regular expression pattern check against
 // the provided webhook URL to ensure that the URL matches the expected
 // pattern.
@@ -386,10 +350,6 @@ func validateWebhookURLRegex(webhookURL string) error {
 func ValidateWebhook(webhookURL string) error {
 
 	if err := validateWebhookLength(webhookURL); err != nil {
-		return err
-	}
-
-	if err := validateWebhookURLPrefix(webhookURL); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/atc0005/go-teams-notify/send.go
+++ b/vendor/github.com/atc0005/go-teams-notify/send.go
@@ -3,7 +3,6 @@ package goteamsnotify
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -17,6 +16,12 @@ import (
 // logger is a package logger that can be enabled from client code to allow
 // logging output from this package when desired/needed for troubleshooting
 var logger *log.Logger
+
+// Known webhook URL prefixes for submitting messages to Microsoft Teams
+const (
+	WebhookURLOfficecomPrefix = "https://outlook.office.com"
+	WebhookURLOffice365Prefix = "https://outlook.office365.com"
+)
 
 // API - interface of MS Teams notify
 type API interface {
@@ -146,19 +151,29 @@ func IsValidInput(webhookMessage MessageCard, webhookURL string) (bool, error) {
 // IsValidWebhookURL performs validation checks on the webhook URL used to
 // submit messages to Microsoft Teams.
 func IsValidWebhookURL(webhookURL string) (bool, error) {
-	// basic URL check
-	_, err := url.Parse(webhookURL)
-	if err != nil {
-		return false, err
-	}
-	// only pass MS teams webhook URLs
+
 	switch {
-	case strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/"):
-	case strings.HasPrefix(webhookURL, "https://outlook.office365.com/webhook/"):
+	case strings.HasPrefix(webhookURL, WebhookURLOfficecomPrefix):
+	case strings.HasPrefix(webhookURL, WebhookURLOffice365Prefix):
 	default:
-		err = errors.New("invalid ms teams webhook url")
-		return false, err
+		u, err := url.Parse(webhookURL)
+		if err != nil {
+			return false, fmt.Errorf(
+				"unable to parse webhook URL %q: %v",
+				webhookURL,
+				err,
+			)
+		}
+		userProvidedWebhookURLPrefix := u.Scheme + "://" + u.Host
+
+		return false, fmt.Errorf(
+			"webhook URL does not contain expected prefix; got %q, expected one of %q or %q",
+			userProvidedWebhookURLPrefix,
+			WebhookURLOfficecomPrefix,
+			WebhookURLOffice365Prefix,
+		)
 	}
+
 	return true, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,2 +1,2 @@
-# github.com/atc0005/go-teams-notify v1.3.1-0.20200409143202-ebfbb4503f85
+# github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e
 github.com/atc0005/go-teams-notify


### PR DESCRIPTION
- Remove `validateWebhookURLPrefix()` func now merged upstream
  to `v2` branch
  - available via our atc0005/go-teams-notify fork for now

- Update atc0005/go-teams-notify fork to include the upstream
  943cdeb90f3e53d1ead03bcc1f86cb5de9b4f264 commit

- Update exported `teams.ValidateWebhook()` func to drop
  call to removed func
  - client code can now call updated, exported upstream
    validation function directly

- `go mod tidy`, `go mod vendor`

fixes #49