### PR TITLE
Implement context support in teams subpkg, app

### DIFF
--- a/cmd/send2teams/main.go
+++ b/cmd/send2teams/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"log"
@@ -79,9 +80,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctxSubmissionTimeout, cancel := context.WithTimeout(context.Background(), config.TeamsSubmissionTimeout)
+	defer cancel()
+
 	// Submit message card, retry submission if needed up to specified number
-	// of retry attempts.
-	if err := teams.SendMessage(cfg.WebhookURL, msgCard, cfg.Retries, cfg.RetriesDelay); err != nil {
+	// of retry attempts or until context expires.
+	if err := teams.SendMessage(ctxSubmissionTimeout, cfg.WebhookURL, msgCard, cfg.Retries, cfg.RetriesDelay); err != nil {
 
 		// Display error output if silence is not requested
 		if !cfg.SilentOutput {

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,18 @@
 
 module github.com/atc0005/send2teams
 
+// replace github.com/atc0005/go-teams-notify => ../go-teams-notify
+
 require (
 	//gopkg.in/dasrick/go-teams-notify.v1 v1.2.0
 
 	// temporarily use our fork while developing changes for potential
 	// inclusion in the upstream project
-	github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e
+	//
+	// temporarily use local copy instead of pinning to a specific commit in
+	// our test branch
+	//github.com/atc0005/go-teams-notify v0.0.0
+	github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e h1:zRyZGkOWTLymKTp96PmPaOO1KIAtS0YBvAeTIKEodNs=
-github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
+github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726 h1:pUJFxj7XRR6UxgWTvG4BCf1cVsn7nNqxdigBhMd1r/c=
+github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726/go.mod h1:zUADEXrhalWyaQvxzYgHswljBWycIpX1UAFrggjcdi4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/atc0005/send2teams/teams"
+	// temporarily use our fork while developing changes for potential
+	// inclusion in the upstream project
 )
 
 const (
@@ -53,6 +56,11 @@ var version string = "dev build"
 // Primarily used with branding
 const myAppName string = "send2teams"
 const myAppURL string = "https://github.com/atc0005/" + myAppName
+
+// TeamsSubmissionTimeout is the timeout value for sending messages to
+// Microsoft Teams. This value is used to build a context with the desired
+// timeout value.
+const TeamsSubmissionTimeout time.Duration = 5 * time.Second
 
 // Config is a unified set of configuration values for this application. This
 // struct is configured via command-line flags provided by the user.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,2 +1,2 @@
-# github.com/atc0005/go-teams-notify v1.3.1-0.20200418112621-bff30feb673e
+# github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 github.com/atc0005/go-teams-notify


### PR DESCRIPTION
- Pin `atc0005/go-teams-notify` at commit atc0005/go-teams-notify@55cca556e7267ec69dc41180591bf666b12321f5
  - provides new `API.SendWithContext()` method

- `teams` subpackage `SendMessage()` now accepts a context and uses it to instrument the new `API.SendWithContext()` method

- Add default `TeamsSubmissionTimeout` to mirror original `dasrick/go-teams-notify` v1 http client timeout

- Tweak log messages to note the current and total number of attempts allowed

fixes #52