### PR TITLE
Add missing -mod=vendor references

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -58,9 +58,9 @@ jobs:
 
       # Force tests to run early as it isn't worth doing much else if the
       # tests fail to run properly.
-      # Note: Exclude `vendor` top-level folder.
+      # Note: The `vendor` top-level folder appears to be skipped by default.
       - name: Run all tests
-        run: go test -mod=vendor -v $(shell go list ./... | grep -v /vendor/)
+        run: go test -mod=vendor -v ./...
 
       - name: Install Go linting tools
         run: |

--- a/Makefile
+++ b/Makefile
@@ -88,16 +88,16 @@ linting:
 		&& exit 1 )
 
 	@echo "Running go vet ..."
-	@go vet -mod=vendor $(shell go list ./... | grep -v /vendor/)
+	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running golint ..."
-	@golint -set_exit_status $(shell go list ./... | grep -v /vendor/)
+	@golint -set_exit_status $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running golangci-lint ..."
 	@golangci-lint run
 
 	@echo "Running staticcheck ..."
-	@staticcheck $(shell go list ./... | grep -v /vendor/)
+	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Finished running linting checks"
 
@@ -105,7 +105,7 @@ linting:
 ## gotests: runs go test recursively, verbosely
 gotests:
 	@echo "Running go tests ..."
-	@go test ./...
+	@go test -mod=vendor ./...
 	@echo "Finished running go tests"
 
 .PHONY: goclean


### PR DESCRIPTION
These missing references are needed to ensure full use of local `vendor` directory.

fixes #64