### PR TITLE
GHAW fixes, golangci-lint, README updates

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright 2020 Adam Chalkley
 #
 # https://github.com/atc0005/send2teams

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright 2020 Adam Chalkley
 #
 # https://github.com/atc0005/send2teams

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - maligned
     - dupl
     - unconvert
+    - gofmt
     - golint
     - gocritic
     - scopelint

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ VERSION 				= $(shell git describe --always --long --dirty)
 
 # https://github.com/golangci/golangci-lint#install
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_LINT_VERSION		= v1.25.0
+GOLANGCI_LINT_VERSION		= v1.25.1
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
@@ -66,7 +66,6 @@ lintinstall:
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Explicitly enabling Go modules mode per command"
-	(cd; GO111MODULE="on" go get golang.org/x/lint/golint)
 	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
 
 	@echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...
@@ -77,21 +76,11 @@ lintinstall:
 
 .PHONY: linting
 ## linting: runs common linting checks
-# https://stackoverflow.com/a/42510278/903870
 linting:
 	@echo "Running linting tools ..."
 
-	@echo "Running gofmt ..."
-
-	@test -z $(shell gofmt -l -e .) || (echo "WARNING: gofmt linting errors found" \
-		&& gofmt -l -e -d . \
-		&& exit 1 )
-
 	@echo "Running go vet ..."
 	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
-
-	@echo "Running golint ..."
-	@golint -set_exit_status $(shell go list -mod=vendor ./... | grep -v /vendor/)
 
 	@echo "Running golangci-lint ..."
 	@golangci-lint run

--- a/README.md
+++ b/README.md
@@ -99,22 +99,19 @@ Tested using:
    - for CentOS Linux
      1. `sudo yum install make gcc`
 1. Build
-   - for current operating system with default `go` build options
-     - `go build ./cmd/send2teams/`
-       - Go 1.14+ automatically uses bundled dependencies in top-level
-         `vendor` folder
-       - Go 1.11, 1.12 and 1.13 will default to fetching dependencies
+   - for current operating system
      - `go build -mod=vendor ./cmd/send2teams/`
-       - force build to use bundled dependencies in top-level `vendor` folder
+       - *forces build to use bundled dependencies in top-level `vendor`
+         folder*
    - for all supported platforms (where `make` is installed)
       - `make all`
    - for Windows
       - `make windows`
    - for Linux
      - `make linux`
-1. Copy the applicable binary to whatever systems that need to run it
-   1. Linux: `/tmp/send2teams/send2teams`
-   1. Windows: `/tmp/send2teams/send2teams.exe`
+1. Copy the applicable binary to whatever systems needs to run it
+   - if using `Makefile`: look in `/tmp/release_assets/send2teams/`
+   - if using `go build`: look in `/tmp/check-mail/`
 
 ## Configuration Options
 


### PR DESCRIPTION
## Changes

- Update golangci-lint to v1.25.1
- Remove bash shegang from GitHub Actions Workflow files
- Update README to list accurate build/deploy steps based on recent restructuring work
- Remove gofmt and golint as separate checks, enable these linters in golangci-lint config

## References

- fixes #69
- fixes #68
- fixes #67
- fixes #66