### PR TITLE
Prune go-yaml/yaml dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	//github.com/atc0005/go-teams-notify v0.0.0
 	github.com/atc0005/go-teams-notify v1.3.1-0.20200419155834-55cca556e726
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
I initially updated the entry in go.mod and ran go mod tidy
accordingly, but then I ran go mod vendor and no dependencies
were updated there.

After removing it from go.mod and running go mod tidy
it was not restored, so at this point it does not look
like this dependency is needed any longer.

refs GH-75