### PR TITLE
Fix various gocritic linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,12 +176,12 @@ func NewConfig() (*Config, error) {
 		return &cfg, nil
 	}
 
-	//log.Debug("Validating configuration ...")
+	// log.Debug("Validating configuration ...")
 	if err := cfg.Validate(); err != nil {
 		flag.Usage()
 		return nil, err
 	}
-	//log.Debug("Configuration validated")
+	// log.Debug("Configuration validated")
 
 	return &cfg, nil
 }


### PR DESCRIPTION
- commentFormatting
  - minor whitespace tweaks
- exitAfterDefer
  - legitimate complaint
  - fixed by using an initial defer of a pointer to int with
    a default value that indicates success. This can be
    overridden as needed to indicate application failure
    without blocking other deferred functions from running.