### PR TITLE
Fix explicit exit code handling

### DIFF
--- a/cmd/send2teams/main.go
+++ b/cmd/send2teams/main.go
@@ -35,14 +35,14 @@ func main() {
 	// default exit code that matches expectations, but allow explicitly
 	// setting the exit code in such a way that is compatible with using
 	// deferred function calls throughout the application.
-	var appExitCode *int
+	var appExitCode int
 	defer func(code *int) {
 		var exitCode int
 		if code != nil {
 			exitCode = *code
 		}
 		os.Exit(exitCode)
-	}(appExitCode)
+	}(&appExitCode)
 
 	// log.Debug("Initializing application")
 
@@ -51,16 +51,16 @@ func main() {
 	// TODO: How else to guard against nil cfg object?
 	case cfg != nil && cfg.ShowVersion:
 		config.Branding()
-		*appExitCode = 0
+		appExitCode = 0
 		return
 	case err == nil:
 		// do nothing for this one
 	case errors.Is(err, flag.ErrHelp):
-		*appExitCode = 0
+		appExitCode = 0
 		return
 	default:
 		log.Printf("failed to initialize application: %s", err)
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 
@@ -87,7 +87,7 @@ func main() {
 	// Add branding trailer section, bail if unexpected error occurs
 	if err := msgCard.AddSection(trailerSection); err != nil {
 		log.Println("error encountered when adding section value:", err)
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 
@@ -113,7 +113,7 @@ func main() {
 		}
 
 		// Regardless of silent flag, explicitly note unsuccessful results
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 


### PR DESCRIPTION
Avoid assignment to uninitialized pointer by using a value
type and explicitly passing a reference to the value type
into the deferred anonymous function. This allows the
intended behavior to work as expected.

refs GH-113