### PR TITLE
Fix context cancellation timeout behavior

### DIFF
--- a/cmd/send2teams/main.go
+++ b/cmd/send2teams/main.go
@@ -91,7 +91,15 @@ func main() {
 		return
 	}
 
-	ctxSubmissionTimeout, cancel := context.WithTimeout(context.Background(), config.TeamsSubmissionTimeout)
+	// This should only trigger if user specifies large retry values.
+	if cfg.TeamsSubmissionTimeout() > config.DefaultNagiosNotificationTimeout {
+		log.Printf(
+			"WARNING: app cancellation timeout value of %v greater than default Nagios command timeout value!",
+			cfg.TeamsSubmissionTimeout(),
+		)
+	}
+
+	ctxSubmissionTimeout, cancel := context.WithTimeout(context.Background(), cfg.TeamsSubmissionTimeout())
 	defer cancel()
 
 	// Create Microsoft Teams client

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
@@ -55,10 +56,15 @@ var version string = "dev build"
 const myAppName string = "send2teams"
 const myAppURL string = "https://github.com/atc0005/" + myAppName
 
-// TeamsSubmissionTimeout is the timeout value for sending messages to
-// Microsoft Teams. This value is used to build a context with the desired
-// timeout value.
-const TeamsSubmissionTimeout time.Duration = 5 * time.Second
+// teamsSubmissionTimeoutMultiplier is the timeout value for sending messages
+// to Microsoft Teams. This value is used along with user specified (or
+// default) retries and retries delay values to calculate a context with the
+// desired timeout value.
+const teamsSubmissionTimeoutMultiplier time.Duration = 2 * time.Second
+
+// DefaultNagiosNotificationTimeout is the default timeout value for Nagios 3
+// and 4 installations. This is our *default* timeout ceiling.
+const DefaultNagiosNotificationTimeout time.Duration = 30 * time.Second
 
 // Config is a unified set of configuration values for this application. This
 // struct is configured via command-line flags provided by the user.
@@ -154,13 +160,25 @@ func flagsUsage() func() {
 }
 
 func (c Config) String() string {
-	return fmt.Sprintf("Team=%q, Channel=%q, WebhookURL=%q, ThemeColor=%q, MessageTitle=%q, MessageText=%q",
+	return fmt.Sprintf(
+		"Team=%q, "+
+			"Channel=%q, "+
+			"WebhookURL=%q, "+
+			"ThemeColor=%q, "+
+			"MessageTitle=%q, "+
+			"MessageText=%q, "+
+			"Retries=%q, "+
+			"RetriesDelay=%q, "+
+			"AppTimeout=%q",
 		c.Team,
 		c.Channel,
 		c.WebhookURL,
 		c.ThemeColor,
 		c.MessageTitle,
 		c.MessageText,
+		strconv.Itoa(c.Retries),
+		strconv.Itoa(c.RetriesDelay),
+		c.TeamsSubmissionTimeout(),
 	)
 }
 

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -1,0 +1,19 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/send2teams
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import "time"
+
+// TeamsSubmissionTimeout is the timeout value for sending messages to
+// Microsoft Teams.
+func (c Config) TeamsSubmissionTimeout() time.Duration {
+
+	return time.Duration(c.Retries) *
+		time.Duration(c.RetriesDelay) *
+		teamsSubmissionTimeoutMultiplier
+}


### PR DESCRIPTION
Prior support of retries and retries delay flags was
unintentionally limited to a hard-coded 5s context cancellation
value. This commit removes that hard-coded limit and instead
sets an application timeout (context cancellation) value
calculated based on a set multipler of 2 and user-specified
retries (default of 2) and retries delay (default of 2) flag
values. By default, the calculation provides an app timeout
of 8s. If the user specifies retries value of 10 and retries
delay of 2 this results in a 40s timeout.

This commit also adds a WARNING message if the calculated
timeout exceeds the default 30s notification timeout applied
by Nagios. If this ends being annoying, we can change the
behavior and place this WARNING behind an optional (future)
flag intended to toggle WARNING messages on/off as desired.

Since this is the first of such WARNING messages, we emit
the message by default.

fixes GH-130