### PR TITLE
Replace use of deprecated function

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,8 +252,11 @@ func (c Config) Validate() error {
 		return fmt.Errorf("retries delay too short")
 	}
 
-	if ok, err := goteamsnotify.IsValidWebhookURL(c.WebhookURL); !ok {
-		return err
+	// Create Microsoft Teams client
+	mstClient := goteamsnotify.NewClient()
+
+	if err := mstClient.ValidateWebhook(c.WebhookURL); err != nil {
+		return fmt.Errorf("webhook URL validation failed: %w", err)
 	}
 
 	// Indicate that we didn't spot any problems


### PR DESCRIPTION
Use `API.ValidateWebhook() method` in place of package-level
`goteamsnotify.IsValidWebhookURL` function which was deprecated
in v2.5.0 of `atc0005/go-teams-notify`.

fixes GH-139