### PR TITLE
Add support for specifying multiple link-back URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Small CLI tool used to submit messages to Microsoft Teams.
   - [Command-line](#command-line)
 - [Examples](#examples)
   - [One-off](#one-off)
+  - [Using an invalid flag](#using-an-invalid-flag)
+  - [Specifying url, description pairs](#specifying-url-description-pairs)
 - [License](#license)
 - [References](#references)
 
@@ -67,6 +69,8 @@ project.
 - optional branding of delivered messages
   - noting this application as the delivery agent
   - (also optional) noting a sending application as the source of the message
+- optional support for specifying target `url`, `description` comma-separated
+  pairs for use as labelled "buttons" within a Microsoft Teams message.
 
 ## Changelog
 
@@ -173,22 +177,23 @@ shadabacc3934](https://gist.github.com/chusiang/895f6406fbf9285c58ad0a3ace13d025
 Currently `send2teams` only supports command-line configuration flags.
 Requests for other configuration sources will be considered.
 
-| Flag            | Required | Default       | Possible                                                  | Description                                                                                                         |
-| --------------- | -------- | ------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `h`, `help`     | No       | N/A           | N/A                                                       | Display Help; show available flags.                                                                                 |
-| `v`, `version`  | No       | `false`       | `true`, `false`                                           | Whether to display application version and then immediately exit application.                                       |
-| `channel`       | No       | `unspecified` | *valid Microsoft Teams channel name*                      | The target channel where we will send a message. If not specified, defaults to `unspecified`.                       |
-| `color`         | No       | `#832561`     | *valid hex color code with leading `#`*                   | The hex color code used to set the desired trim color on submitted messages.                                        |
-| `message`       | Yes      |               | *valid message string*                                    | The (optionally) Markdown-formatted message to submit.                                                              |
-| `team`          | No       | `unspecified` | *valid Microsoft Teams team name*                         | The name of the Team containing our target channel. If not specified, defaults to `unspecified`.                    |
-| `title`         | Yes      |               | *valid title string*                                      | The title for the message to submit.                                                                                |
-| `sender`        | No       |               | *valid application or script name*                        | The (optional) sending application name or generator of the message this app will attempt to deliver.               |
-| `url`           | Yes      |               | [*valid Microsoft Office 365 Webhook URL*](#webhook-urls) | The Webhook URL provided by a pre-configured Connector.                                                             |
-| `verbose`       | No       | `false`       | `true`, `false`                                           | Whether detailed output should be shown after message submission success or failure                                 |
-| `silent`        | No       | `false`       | `true`, `false`                                           | Whether ANY output should be shown after message submission success or failure                                      |
-| `convert-eol`   | No       | `false`       | `true`, `false`                                           | Whether messages with Windows, Mac and Linux newlines are updated to use break statements before message submission |
-| `retries`       | No       | `2`           | *positive whole number*                                   | The number of attempts that this application will make to deliver messages before giving up.                        |
-| `retries-delay` | No       | `2`           | *positive whole number*                                   | The number of seconds that this application will wait before making another delivery attempt.                       |
+| Flag            | Required | Default       | Possible                                                    | Description                                                                                                                                 |
+| --------------- | -------- | ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `h`, `help`     | No       | N/A           | N/A                                                         | Display Help; show available flags.                                                                                                         |
+| `v`, `version`  | No       | `false`       | `true`, `false`                                             | Whether to display application version and then immediately exit application.                                                               |
+| `channel`       | No       | `unspecified` | *valid Microsoft Teams channel name*                        | The target channel where we will send a message. If not specified, defaults to `unspecified`.                                               |
+| `color`         | No       | `#832561`     | *valid hex color code with leading `#`*                     | The hex color code used to set the desired trim color on submitted messages.                                                                |
+| `message`       | Yes      |               | *valid message string*                                      | The (optionally) Markdown-formatted message to submit.                                                                                      |
+| `team`          | No       | `unspecified` | *valid Microsoft Teams team name*                           | The name of the Team containing our target channel. If not specified, defaults to `unspecified`.                                            |
+| `title`         | Yes      |               | *valid title string*                                        | The title for the message to submit.                                                                                                        |
+| `sender`        | No       |               | *valid application or script name*                          | The (optional) sending application name or generator of the message this app will attempt to deliver.                                       |
+| `url`           | Yes      |               | [*valid Microsoft Office 365 Webhook URL*](#webhook-urls)   | The Webhook URL provided by a pre-configured Connector.                                                                                     |
+| `target-url`    | No       |               | *valid comma-separated `url`, `description` pair* (limit 4) | The target URL and label (specified as comma separated pair) usually visible as a button towards the bottom of the Microsoft Teams message. |
+| `verbose`       | No       | `false`       | `true`, `false`                                             | Whether detailed output should be shown after message submission success or failure                                                         |
+| `silent`        | No       | `false`       | `true`, `false`                                             | Whether ANY output should be shown after message submission success or failure                                                              |
+| `convert-eol`   | No       | `false`       | `true`, `false`                                             | Whether messages with Windows, Mac and Linux newlines are updated to use break statements before message submission                         |
+| `retries`       | No       | `2`           | *positive whole number*                                     | The number of attempts that this application will make to deliver messages before giving up.                                                |
+| `retries-delay` | No       | `2`           | *positive whole number*                                     | The number of seconds that this application will wait before making another delivery attempt.                                               |
 
 ## Examples
 
@@ -223,10 +228,34 @@ and on a single line (e.g., one-off via terminal or batch file):
 Remove the `-silent` flag in order to see pass or failure output, otherwise
 look at the exit code (`$?`) or Microsoft Teams to determine results.
 
+### Using an invalid flag
+
 Accidentally typing the wrong flag results in a message like this one:
 
 ```ShellSession
 flag provided but not defined: -fake-flag
+```
+
+### Specifying url, description pairs
+
+```console
+./send2teams \
+  --silent \
+  --channel "Alerts" \
+  --team "Support" \
+  --message "Useful starting points" \
+  --title "Learn more about Go" \
+  --sender "Nagios" \
+  --color "#832561" \
+  --url "https://outlook.office.com/webhook/www@xxx/IncomingWebhook/yyy/zzz" \
+  --target-url "https://www.golang.org/, Go Homepage" \
+  --target-url "https://github.com/dariubs/GoBooks, Awesome Go Books"
+```
+
+and on a single line (e.g., one-off via terminal or batch file):
+
+```console
+./send2teams.exe --silent --channel "Alerts" --team "Support" --message "Useful starting points" --title "Learn more about Go" --sender "Nagios" --color "#832561" --url "https://outlook.office.com/webhook/www@xxx/IncomingWebhook/yyy/zzz" --target-url "https://www.golang.org/, Go Homepage" --target-url "https://github.com/dariubs/GoBooks, Awesome Go Books"
 ```
 
 ## License

--- a/cmd/send2teams/main.go
+++ b/cmd/send2teams/main.go
@@ -79,6 +79,44 @@ func main() {
 	msgCard.Text = cfg.MessageText
 	msgCard.ThemeColor = cfg.ThemeColor
 
+	// If provided, use target URLs and their descriptions to add labelled URL
+	// "buttons" to Microsoft Teams message.
+	if cfg.TargetURLs != nil {
+
+		// Create dedicated section for all potentialAction items
+		actionSection := goteamsnotify.NewMessageCardSection()
+		actionSection.StartGroup = true
+
+		for i := range cfg.TargetURLs {
+
+			pa := goteamsnotify.NewMessageCardPotentialAction(
+				goteamsnotify.PotentialActionOpenURIType,
+				cfg.TargetURLs[i].Description,
+			)
+
+			pa.MessageCardPotentialActionOpenURI.Targets =
+				[]goteamsnotify.MessageCardPotentialActionOpenUriTarget{
+					{
+						OS:  "default",
+						URI: cfg.TargetURLs[i].URL.String(),
+					},
+				}
+
+			if err := actionSection.AddPotentialAction(pa); err != nil {
+				log.Println("error encountered when adding target URL to message:", err)
+				appExitCode = 1
+
+				return
+			}
+		}
+
+		if err := msgCard.AddSection(actionSection); err != nil {
+			log.Println("error encountered when adding section value:", err)
+			appExitCode = 1
+			return
+		}
+	}
+
 	// Create branding trailer section
 	trailerSection := goteamsnotify.NewMessageCardSection()
 	trailerSection.Text = config.MessageTrailer(cfg.Sender)

--- a/doc.go
+++ b/doc.go
@@ -32,40 +32,11 @@ FEATURES
 
 • message delivery retry support with retry and retry delay values configurable via flag
 
+• optional support for specifying url/description pairs for display in Microsoft Teams messages
 
 USAGE
 
-Help output is below. See the README for examples.
-
-	send2teams dev build
-	https://github.com/atc0005/send2teams
-
-	Usage of "send2teams.exe":
-	-channel string
-			The target channel where we will send a message.
-	-color string
-			The hex color code used to set the desired trim color on submitted messages. (default "#832561")
-	-convert-eol
-			Whether messages with Windows, Mac and Linux newlines are updated to use break statements before message submission.
-	-message string
-			The message to submit. This message may be provided in Markdown format.
-	-retries int
-			The number of attempts that this application will make to deliver messages before giving up. (default 2)
-	-retries-delay int
-			The number of seconds that this application will wait before making another delivery attempt. (default 2)
-	-silent
-			Whether ANY output should be shown after message submission success or failure.
-	-team string
-			The name of the Team containing our target channel.
-	-title string
-			The title for the message to submit.
-	-url string
-			The Webhook URL provided by a preconfigured Connector.
-	-v    Whether to display application version and then immediately exit application. (shorthand)
-	-verbose
-			Whether detailed output should be shown after message submission success or failure.
-	-version
-			Whether to display application version and then immediately exit application.
+See our main README for supported settings and examples.
 
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@
 
 module github.com/atc0005/send2teams
 
+// TODO: Review this after atc0005/go-teams-notify#103 and any follow-up PRs are merged.
+replace github.com/atc0005/go-teams-notify/v2 => github.com/nmaupu/go-teams-notify/v2 v2.4.3-0.20210426083400-b9e05e82de91
+
 require (
 	github.com/atc0005/go-teams-notify/v2 v2.5.0
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/atc0005/go-teams-notify/v2 v2.5.0 h1:WKkrbYe2gfT76rltlWTjg8Eukvz0tvzAqs2jyC3pQe0=
-github.com/atc0005/go-teams-notify/v2 v2.5.0/go.mod h1:BSlh1HBcgWcGoNM3Abm36WMPcj+k8Wf0ZLZx6lBx2qk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/nmaupu/go-teams-notify/v2 v2.4.3-0.20210426083400-b9e05e82de91 h1:w8Pj9UQ54tZYUqziFF5A7vN6TBo6a01y4QU16LGg6ag=
+github.com/nmaupu/go-teams-notify/v2 v2.4.3-0.20210426083400-b9e05e82de91/go.mod h1:BSlh1HBcgWcGoNM3Abm36WMPcj+k8Wf0ZLZx6lBx2qk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -17,6 +17,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.BoolVar(&c.SilentOutput, "silent", defaultSilentOutput, silentOutputFlagHelp)
 	flag.BoolVar(&c.ConvertEOL, "convert-eol", defaultConvertEOL, convertEOLFlagHelp)
 	flag.StringVar(&c.Team, "team", defaultTeamName, teamNameFlagHelp)
+	flag.Var(&c.TargetURLs, "target-url", targetURLFlagHelp)
 	flag.StringVar(&c.Channel, "channel", defaultChannelName, channelNameFlagHelp)
 	flag.StringVar(&c.WebhookURL, "url", defaultWebhookURL, webhookURLFlagHelp)
 	flag.StringVar(&c.ThemeColor, "color", defaultMessageThemeColor, themeColorFlagHelp)

--- a/vendor/github.com/atc0005/go-teams-notify/v2/messagecard.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/messagecard.go
@@ -14,6 +14,177 @@ import (
 	"strings"
 )
 
+const (
+	// PotentialActionOpenURIType is the type that must be used for OpenUri potential action.
+	PotentialActionOpenURIType = "OpenUri"
+	// PotentialActionHTTPPostType is the type that must be used for HttpPOST potential action.
+	PotentialActionHTTPPostType = "HttpPOST"
+	// PotentialActionActionCardType is the type that must be used for ActionCard potential action.
+	PotentialActionActionCardType = "ActionCard"
+	// PotentialActionInvokeAddInCommandType is the type that must be used for InvokeAddInCommand potential action.
+	PotentialActionInvokeAddInCommandType = "InvokeAddInCommand"
+
+	// PotentialActionActionCardInputTextInputType is the type that must be used for ActionCard TextInput type.
+	PotentialActionActionCardInputTextInputType = "TextInput"
+	// PotentialActionActionCardInputDateInputType is the type that must be used for ActionCard DateInput type.
+	PotentialActionActionCardInputDateInputType = "DateInput"
+	// PotentialActionActionCardInputMultichoiceInput is the type that must be used for ActionCard MultichoiceInput type.
+	PotentialActionActionCardInputMultichoiceInput = "MultichoiceInput"
+)
+
+// PotentialActionMaxSupported is the maximum number of actions allowed in a
+// MessageCardPotentialAction collection.
+// https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions
+const PotentialActionMaxSupported = 4
+
+// MessageCardPotentialAction represents potential actions an user can do in a message card.
+// See https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions for more information.
+type MessageCardPotentialAction struct {
+	// Type of the potential action.
+	// Can be OpenUri, HttpPOST, ActionCard or InvokeAddInCommand.
+	Type string `json:"@type"`
+	// Name property defines the text that will be displayed on screen for the action.
+	Name string `json:"name"`
+	// MessageCardPotentialActionOpenURI is a set of options for openUri potential action.
+	MessageCardPotentialActionOpenURI
+	// MessageCardPotentialActionHttpPOST is a set of options for httpPOST potential action.
+	MessageCardPotentialActionHttpPOST
+	// MessageCardPotentialActionActionCard is a set of options for actionCard potential action.
+	MessageCardPotentialActionActionCard
+	// MessageCardPotentialActionInvokeAddInCommand is a set of options for invokeAddInCommand potential action.
+	MessageCardPotentialActionInvokeAddInCommand
+}
+
+// MessageCardPotentialActionOpenURI represents a OpenUri potential action.
+type MessageCardPotentialActionOpenURI struct {
+	// Targets is a collection of name/value pairs that defines one URI per target operating system.
+	// Only used for OpenUri action type.
+	Targets []MessageCardPotentialActionOpenUriTarget `json:"targets,omitempty"`
+}
+
+// MessageCardPotentialActionHttpPOST represents a HttpPOST potential action.
+type MessageCardPotentialActionHttpPOST struct {
+	// Target defines the URL endpoint of the service that implements the action.
+	// Only used for HttpPOST action type.
+	Target string `json:"target,omitempty"`
+	// Headers is a collection of MessageCardPotentialActionHeader objects representing a set of HTTP headers that will be emitted when sending the POST request to the target URL.
+	// Only used for HttpPOST action type.
+	Headers []MessageCardPotentialActionHttpPOSTHeader `json:"headers,omitempty"`
+	// Body is the body of the POST request.
+	// Only used for HttpPOST action type.
+	Body string `json:"body,omitempty"`
+	// BodyContentType is optional and specifies the MIME type of the body in the POST request.
+	// Only used for HttpPOST action type.
+	BodyContentType string `json:"bodyContentType,omitempty"`
+}
+
+// MessageCardPotentialActionActionCard represents an actionCard potential action.
+type MessageCardPotentialActionActionCard struct {
+	// Inputs is a collection of inputs an user can provide before processing the actions.
+	// Only used for ActionCard action type.
+	// Three types of inputs are available: TextInput, DateInput and MultichoiceInput
+	Inputs []MessageCardPotentialActionActionCardInput `json:"inputs,omitempty"`
+	// Actions are the available actions.
+	// Only used for ActionCard action type.
+	Actions []MessageCardPotentialActionActionCardAction `json:"actions,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardAction is used for configuring ActionCard actions
+type MessageCardPotentialActionActionCardAction struct {
+	// Type of the action.
+	// Can be OpenUri, HttpPOST, ActionCard or InvokeAddInCommand.
+	Type string `json:"@type"`
+	// Name property defines the text that will be displayed on screen for the action.
+	Name string `json:"name"`
+	// MessageCardPotentialActionOpenURI is used to specify a openUri action card's action.
+	MessageCardPotentialActionOpenURI
+	// MessageCardPotentialActionHttpPOST is used to specify a httpPOST action card's action.
+	MessageCardPotentialActionHttpPOST
+}
+
+// MessageCardPotentialActionInvokeAddInCommand represents an invokeAddInCommand potential action.
+type MessageCardPotentialActionInvokeAddInCommand struct {
+	// AddInID specifies the add-in ID of the required add-in.
+	// Only used for InvokeAddInCommand action type.
+	AddInID string `json:"addInId,omitempty"`
+	// DesktopCommandID specifies the ID of the add-in command button that opens the required task pane.
+	// Only used for InvokeAddInCommand action type.
+	DesktopCommandID string `json:"desktopCommandId,omitempty"`
+	// InitializationContext is an optional field which provides developers a way to specify any valid JSON object.
+	// The value is serialized into a string and made available to the add-in when the action is executed.
+	// This allows the action to pass initialization data to the add-in.
+	// Only used for InvokeAddInCommand action type.
+	InitializationContext interface{} `json:"initializationContext,omitempty"`
+}
+
+// MessageCardPotentialActionOpenUriTarget is used for OpenUri action type.
+// It defines one URI per target operating system.
+type MessageCardPotentialActionOpenUriTarget struct {
+	// OS defines the operating system the target uri refers to.
+	// Supported operating system values are default, windows, iOS and android.
+	// The default operating system will in most cases simply open the URI in a web browser, regardless of the actual operating system.
+	OS string `json:"os,omitempty"`
+	// URI defines the URI being called.
+	URI string `json:"uri,omitempty"`
+}
+
+// MessageCardPotentialActionHttpPOSTHeader defines a HTTP header used for HttpPOST action type.
+type MessageCardPotentialActionHttpPOSTHeader struct {
+	// Name is the header name.
+	Name string `json:"name,omitempty"`
+	// Value is the header value.
+	Value string `json:"value,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInput represents an ActionCard input.
+type MessageCardPotentialActionActionCardInput struct {
+	// Type of the ActionCard input.
+	// Must be either TextInput, DateInput or MultichoiceInput
+	Type string `json:"@type"`
+	// ID uniquely identifies the input so it is possible to reference it in the URL or body of an HttpPOST action.
+	ID string `json:"id,omitempty"`
+	// IsRequired indicates whether users are required to type a value before they are able to take an action that would take the value of the input as a parameter.
+	IsRequired bool `json:"isRequired,omitempty"`
+	// Title defines a title for the input.
+	Title string `json:"title,omitempty"`
+	// Value defines the initial value of the input. For multi-choice inputs, value must be equal to the value property of one of the input's choices.
+	Value string `json:"value,omitempty"`
+
+	// MessageCardPotentialActionInputTextInput must be defined for InputText input type.
+	MessageCardPotentialActionActionCardInputTextInput
+	// MessageCardPotentialActionInputDateInput must be defined for DateInput input type.
+	MessageCardPotentialActionActionCardInputDateInput
+	// MessageCardPotentialActionInputMultichoiceInput must be defined for MultichoiceInput input type.
+	MessageCardPotentialActionActionCardInputMultichoiceInput
+}
+
+// MessageCardPotentialActionActionCardInputTextInput represents a TextInput input used for potential action.
+type MessageCardPotentialActionActionCardInputTextInput struct {
+	// IsMultiline indicates whether the text input should accept multiple lines of text.
+	IsMultiline bool `json:"isMultiline,omitempty"`
+	// MaxLength indicates the maximum number of characters that can be entered.
+	MaxLength int `json:"maxLength,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInputMultichoiceInput represents a MultichoiceInput input used for potential action.
+type MessageCardPotentialActionActionCardInputMultichoiceInput struct {
+	// Choices defines the values that can be selected for the multichoice input.
+	Choices []struct {
+		Display string `json:"display,omitempty"`
+		Value   string `json:"value,omitempty"`
+	} `json:"choices,omitempty"`
+	// IsMultiSelect indicates whether or not the user can select more than one choice. The specified choices will be displayed as a list of checkboxes. Default value is false.
+	IsMultiSelect bool `json:"isMultiSelect,omitempty"`
+	// Style defines the style of the input. When IsMultiSelect is false, setting the style property to expanded will instruct the host application to try and display all choices on the screen, typically using a set of radio buttons.
+	Style string `json:"style,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInputDateInput represents a DateInput input used for potential action.
+type MessageCardPotentialActionActionCardInputDateInput struct {
+	// IncludeTime indicates whether the date input should allow for the selection of a time in addition to the date.
+	IncludeTime bool `json:"includeTime,omitempty"`
+}
+
 // MessageCardSectionFact represents a section fact entry that is usually
 // displayed in a two-column key/value format.
 type MessageCardSectionFact struct {
@@ -98,6 +269,9 @@ type MessageCardSection struct {
 	// https://stackoverflow.com/questions/33447334/golang-json-marshal-how-to-omit-empty-nested-struct
 	Images []*MessageCardSectionImage `json:"images,omitempty"`
 
+	// TODO: Add this for original PR
+	PotentialActions []*MessageCardPotentialAction `json:"potentialAction,omitempty"`
+
 	// Markdown represents a toggle to enable or disable Markdown formatting.
 	// By default, all text fields in a card and its sections can be formatted
 	// using basic Markdown.
@@ -147,6 +321,8 @@ type MessageCard struct {
 
 	// Sections is a collection of sections to include in the card.
 	Sections []*MessageCardSection `json:"sections,omitempty"`
+
+	PotentialActions []*MessageCardPotentialAction `json:"potentialAction,omitempty"`
 }
 
 // AddSection adds one or many additional MessageCardSection values to a
@@ -174,6 +350,9 @@ func (mc *MessageCard) AddSection(section ...*MessageCardSection) error {
 		// statement and add the section.
 		case s.Images != nil:
 		case s.Facts != nil:
+
+		// TODO: Does this make sense? Would this alone be enough to make the section "good enough" for use?
+		case s.PotentialActions != nil:
 		case s.HeroImage != nil:
 		case s.StartGroup:
 		case s.Markdown:
@@ -191,6 +370,31 @@ func (mc *MessageCard) AddSection(section ...*MessageCardSection) error {
 
 		logger.Println("AddSection: section contains at least one non-zero value, adding section")
 		mc.Sections = append(mc.Sections, s)
+	}
+
+	return nil
+}
+
+func (mc *MessageCard) AddPotentialAction(actions ...*MessageCardPotentialAction) error {
+	for _, a := range actions {
+		logger.Printf("AddPotentialAction: MessageCardPotentialAction received: %+v\n", a)
+
+		if a == nil {
+			return fmt.Errorf("func AddPotentialAction: nil MessageCardPotentialAction received")
+		}
+
+		switch a.Type {
+		case PotentialActionOpenURIType,
+			PotentialActionHTTPPostType,
+			PotentialActionActionCardType,
+			PotentialActionInvokeAddInCommandType:
+
+		default:
+			logger.Printf("AddPotentialAction: unknown type %s for action %s\n", a.Type, a.Name)
+			return fmt.Errorf("unknown type %s for potential action %s", a.Type, a.Name)
+		}
+
+		mc.PotentialActions = append(mc.PotentialActions, a)
 	}
 
 	return nil
@@ -260,6 +464,32 @@ func (mcs *MessageCardSection) AddFactFromKeyValue(key string, values ...string)
 	mcs.Facts = append(mcs.Facts, fact)
 
 	// if we made it this far then all should be well
+	return nil
+}
+
+// TODO: Need to determine whether to include this in original PR, or as a follow-up
+func (mcs *MessageCardSection) AddPotentialAction(actions ...*MessageCardPotentialAction) error {
+	for _, a := range actions {
+		logger.Printf("AddPotentialAction: MessageCardPotentialAction received: %+v\n", a)
+
+		if a == nil {
+			return fmt.Errorf("func AddPotentialAction: nil MessageCardPotentialAction received")
+		}
+
+		switch a.Type {
+		case PotentialActionOpenURIType,
+			PotentialActionHTTPPostType,
+			PotentialActionActionCardType,
+			PotentialActionInvokeAddInCommandType:
+
+		default:
+			logger.Printf("AddPotentialAction: unknown type %s for action %s\n", a.Type, a.Name)
+			return fmt.Errorf("unknown type %s for potential action %s", a.Type, a.Name)
+		}
+
+		mcs.PotentialActions = append(mcs.PotentialActions, a)
+	}
+
 	return nil
 }
 
@@ -356,4 +586,11 @@ func NewMessageCardSectionFact() MessageCardSectionFact {
 func NewMessageCardSectionImage() MessageCardSectionImage {
 	msgCardSectionImage := MessageCardSectionImage{}
 	return msgCardSectionImage
+}
+
+func NewMessageCardPotentialAction(potentialActionType, name string) *MessageCardPotentialAction {
+	return &MessageCardPotentialAction{
+		Type: potentialActionType,
+		Name: name,
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,6 @@
-# github.com/atc0005/go-teams-notify/v2 v2.5.0
+# github.com/atc0005/go-teams-notify/v2 v2.5.0 => github.com/nmaupu/go-teams-notify/v2 v2.4.3-0.20210426083400-b9e05e82de91
 ## explicit
 github.com/atc0005/go-teams-notify/v2
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
+# github.com/atc0005/go-teams-notify/v2 => github.com/nmaupu/go-teams-notify/v2 v2.4.3-0.20210426083400-b9e05e82de91


### PR DESCRIPTION
## Overview

This commit implements support for specifying multiple URLs via CLI flags. These URLs are exposed as labelled "buttons" towards the bottom of the generated Microsoft Teams message.

Light documentation updates have been applied, including usage of the new `--target-url` flag.

## Known issues

This commit also includes modified, vendored WIP changes from atc0005/go-teams-notify#103 that have yet to be
merged into that project. The intent is to update to the latest stable tag once that PR and any follow-up PRs are merged. 

Some code changes to this app will likely be needed after that stable tag is available (e.g., exported constants).

## References

- refs atc0005/go-teams-notify#103
- fixes atc0005/send2teams#148
- fixes atc0005/send2teams#120
