### PR TITLE
Cleanup config initialization

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -56,6 +57,10 @@ const (
 
 // Overridden via Makefile for release builds
 var version string = "dev build"
+
+// ErrVersionRequested indicates that the user requested application version
+// information.
+var ErrVersionRequested = errors.New("version information requested")
 
 // Primarily used with branding
 const myAppName string = "send2teams"


### PR DESCRIPTION
- Use sentinel error to indicate that app version details
  were requested
- Drop non-error case since we're not doing anything special
  with that scenario
- Move appExitCode handling block below config init since it
  is not needed prior to that point
- Drop commented out logger call, invalid pkg func call