### PR TITLE
Add test/CI coverage for --version flag

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -83,3 +83,7 @@ jobs:
       - name: Build using vendored dependencies
         run: |
           go build -v -mod=vendor ./cmd/send2teams
+
+      - name: Use executable version CLI flag
+        run: |
+          ./send2teams --version

--- a/cmd/send2teams/main_test.go
+++ b/cmd/send2teams/main_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/send2teams
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/atc0005/send2teams/internal/config"
+)
+
+// Setup basic tests to ensure that config initialization works as expected.
+
+func TestConfigInitialization(t *testing.T) {
+
+	// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
+
+	// Save old command-line arguments so that we can restore them later
+	oldArgs := os.Args
+
+	// Defer restoring original command-line arguments
+	defer func() { os.Args = oldArgs }()
+
+	// Note to self: Don't add/escape double-quotes here. The shell strips
+	// them away and the application never sees them.
+	os.Args = []string{
+		"/usr/local/bin/qm", "--version",
+	}
+
+	// based on given CLI args, we *should* have a sentinel error here.
+	_, cfgErr := config.NewConfig()
+
+	if !errors.Is(cfgErr, config.ErrVersionRequested) {
+		t.Fatalf("got %v; expected error %q", cfgErr, config.ErrVersionRequested)
+	} else {
+		config.Branding()
+		t.Log("--version flag properly recognized")
+	}
+
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,7 +329,7 @@ func NewConfig() (*Config, error) {
 
 	// Return immediately if user just wants version details
 	if cfg.ShowVersion {
-		return &cfg, nil // BUG: GH-165
+		return &cfg, ErrVersionRequested
 	}
 
 	// log.Debug("Validating configuration ...")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,7 +329,7 @@ func NewConfig() (*Config, error) {
 
 	// Return immediately if user just wants version details
 	if cfg.ShowVersion {
-		return &cfg, nil
+		return &cfg, nil // BUG: GH-165
 	}
 
 	// log.Debug("Validating configuration ...")


### PR DESCRIPTION
- Add basic test to validate expected config init results when `--version` flag is specified
- Add CI post-build step to call generated binary with `--version` flag
- Fix unintentional bug introduced with refactoring of config initialization in GH-157

fixes GH-165