### PR TITLE
Update README to list release binaries as alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Small CLI tool used to submit messages to Microsoft Teams.
 - [Changelog](#changelog)
 - [Requirements](#requirements)
 - [How to install it](#how-to-install-it)
+  - [From source](#from-source)
+  - [Using release binaries](#using-release-binaries)
 - [Configuration Options](#configuration-options)
   - [Webhook URLs](#webhook-urls)
     - [Expected format](#expected-format)
@@ -96,6 +98,8 @@ Tested using:
 
 ## How to install it
 
+### From source
+
 1. [Download](https://golang.org/dl/) Go
 1. [Install](https://golang.org/doc/install) Go
 1. Clone the repo
@@ -121,6 +125,14 @@ Tested using:
 1. Copy the applicable binary to whatever systems needs to run it
    - if using `Makefile`: look in `/tmp/release_assets/send2teams/`
    - if using `go build`: look in `/tmp/send2teams/`
+
+### Using release binaries
+
+1. Download the [latest
+   release](https://github.com/atc0005/send2teams/releases/latest) binaries
+1. Deploy
+   - Place `send2teams` in a location of your choice
+     - e.g., `/usr/local/bin/send2teams`
 
 ## Configuration Options
 


### PR DESCRIPTION
Previously only building from source was suggested as a means
of installing a binary for use.

fixes GH-180