### PR TITLE
Add linting using unstable & oldstable containers

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -20,8 +20,22 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Don't flag the whole workflow as failed if "experimental" matrix jobs
+    # fail. This allows the unstable image linting tasks to fail without
+    # marking the oldstable and stable image linting jobs as failed.
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      # Don't stop all workflow jobs if the unstable image linting tasks fail.
+      fail-fast: false
+      matrix:
+        container-image: ["go-ci-oldstable", "go-ci-stable"]
+        experimental: [false]
+        include:
+          - container-image: "go-ci-unstable"
+            experimental: true
+
     container:
-      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Use the same matrix of containers for linting in the `Validate Codebase` GHAW that we're already using for testing and building jobs.

This applies the minimum linting requirements in addition to testing "unstable" linting options that may become the new baseline in the future.

One notable difference is that out of the matrix of containers used for linting we mark the unstable container as "experimental" and configure the job to ignore linting errors generated by that container. This effectively makes any linting output from the unstable container informational only as intended.

fixes GH-206
