### PR TITLE
Override default user agent

### DIFF
--- a/cmd/send2teams/main.go
+++ b/cmd/send2teams/main.go
@@ -136,6 +136,9 @@ func main() {
 	// Create Microsoft Teams client
 	mstClient := goteamsnotify.NewClient()
 
+	// Override User Agent.
+	mstClient.SetUserAgent(cfg.UserAgent())
+
 	// Disable webhook URL validation if requested by user.
 	mstClient.SkipWebhookURLValidationOnSend(cfg.DisableWebhookURLValidation)
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ module github.com/atc0005/send2teams
 
 go 1.17
 
-require github.com/atc0005/go-teams-notify/v2 v2.6.0
+require github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd
 
 require github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify/v2 v2.6.0 h1:YegKDWbjlatR0fP2yHsQYXzTcUGNJXhm1/OiCgbyysc=
-github.com/atc0005/go-teams-notify/v2 v2.6.0/go.mod h1:xo6GejLDHn3tWBA181F8LrllIL0xC1uRsRxq7YNXaaY=
+github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd h1:2QMH6RkOoTIX7omCraj2duiNoYdzX2QetCzL/zEDpFU=
+github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd/go.mod h1:xo6GejLDHn3tWBA181F8LrllIL0xC1uRsRxq7YNXaaY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,20 @@ const brandingTextPrefix string = "Message delivered by"
 // one will attempt to deliver to a Microsoft Teams channel.
 const brandingTextSuffix string = "on behalf of"
 
+// AppInfo identifies common details about the tools provided by this project.
+type AppInfo struct {
+
+	// Name specifies the public name shared by all tools in this project.
+	Name string
+
+	// Version specifies the public version shared by all tool in this
+	// project.
+	Version string
+
+	// URL specifies the public repo URL shared by all tools in this project.
+	URL string
+}
+
 // TargetURL is a URL and description provided by the user for use with
 // generating potentialAction entries for display as "buttons" in the
 // generated Microsoft Teams message.
@@ -143,6 +157,9 @@ type Config struct {
 	// responsible for generating the message that this one will attempt to
 	// deliver.
 	Sender string
+
+	// App represents common details about the tools provided by this project.
+	App AppInfo
 
 	// TargetURLs is the collection of user-specified URLs and descriptions
 	// that should be displayed as actionable links or "buttons" within the
@@ -349,6 +366,12 @@ func NewConfig() (*Config, error) {
 	cfg := Config{}
 
 	cfg.handleFlagsConfig()
+
+	cfg.App = AppInfo{
+		Name:    myAppName,
+		Version: version,
+		URL:     myAppURL,
+	}
 
 	// Return immediately if user just wants version details
 	if cfg.ShowVersion {

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -7,7 +7,10 @@
 
 package config
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // TeamsSubmissionTimeout is the timeout value for sending messages to
 // Microsoft Teams.
@@ -16,4 +19,18 @@ func (c Config) TeamsSubmissionTimeout() time.Duration {
 	return time.Duration(c.Retries) *
 		time.Duration(c.RetriesDelay) *
 		teamsSubmissionTimeoutMultiplier
+}
+
+// UserAgent returns a string usable as-is as a custom user agent for plugins
+// provided by this project.
+func (c Config) UserAgent() string {
+
+	// Default User Agent: (Go-http-client/1.1)
+	// https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-p2-semantics-22#section-5.5.3
+	return fmt.Sprintf(
+		"%s/%s",
+		c.App.Name,
+		c.App.Version,
+	)
+
 }

--- a/vendor/github.com/atc0005/go-teams-notify/v2/README.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/README.md
@@ -27,6 +27,7 @@ A package to send messages to Microsoft Teams (channels)
     - [How to create a webhook URL (Connector)](#how-to-create-a-webhook-url-connector)
   - [Examples](#examples)
     - [Basic](#basic)
+    - [Set custom user agent](#set-custom-user-agent)
     - [Add an Action](#add-an-action)
     - [Disable webhook URL prefix validation](#disable-webhook-url-prefix-validation)
     - [Enable custom patterns' validation](#enable-custom-patterns-validation)
@@ -69,6 +70,8 @@ information.
     validation behavior
 - Configurable timeouts
 - Configurable retry support
+- Support for overriding the default `http.Client`
+- Support for overriding default project-specific user agent
 
 ## Project Status
 
@@ -183,6 +186,12 @@ shadabacc3934](https://gist.github.com/chusiang/895f6406fbf9285c58ad0a3ace13d025
 This is an example of a simple client application which uses this library.
 
 File: [basic](./examples/basic/main.go)
+
+#### Set custom user agent
+
+This example illustrates setting a custom user agent.
+
+File: [custom-user-agent](./examples/custom-user-agent/main.go)
 
 #### Add an Action
 

--- a/vendor/github.com/atc0005/go-teams-notify/v2/doc.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/doc.go
@@ -33,6 +33,10 @@ FEATURES
 
 • Configurable retry support
 
+• Support for overriding the default http.Client
+
+• Support for overriding the default project-specific user agent
+
 
 USAGE
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/atc0005/go-teams-notify/v2 v2.6.0
+# github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd
 ## explicit; go 1.14
 github.com/atc0005/go-teams-notify/v2
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Use new `SetUserAgent()` `API` method from `atc0005/go-teams-notify` project to override the default Go user agent when submitting messages.

fixes GH-203