### PR TITLE
Add initial support for user mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Small CLI tool used to submit messages to Microsoft Teams.
   - [One-off](#one-off)
   - [Using an invalid flag](#using-an-invalid-flag)
   - [Specifying url, description pairs](#specifying-url-description-pairs)
+  - [User mention](#user-mention)
 - [License](#license)
 - [References](#references)
 
@@ -69,6 +70,7 @@ project.
   `<br>` to increase compatibility with Teams formatting
 - message delivery retry support with retry and retry delay values
   configurable via flag
+- Support for user mentions (limited)
 - optional branding of delivered messages
   - noting this application as the delivery agent
   - (also optional) noting a sending application as the source of the message
@@ -201,25 +203,26 @@ shadabacc3934](https://gist.github.com/chusiang/895f6406fbf9285c58ad0a3ace13d025
 Currently `send2teams` only supports command-line configuration flags.
 Requests for other configuration sources will be considered.
 
-| Flag                      | Required | Default       | Possible                                                    | Description                                                                                                                                 |
-| ------------------------- | -------- | ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `h`, `help`               | No       | N/A           | N/A                                                         | Display Help; show available flags.                                                                                                         |
-| `v`, `version`            | No       | `false`       | `true`, `false`                                             | Whether to display application version and then immediately exit application.                                                               |
-| `channel`                 | No       | `unspecified` | *valid Microsoft Teams channel name*                        | The target channel where we will send a message. If not specified, defaults to `unspecified`.                                               |
-| `color`                   | No       | `#832561`     | *valid hex color code with leading `#`*                     | The hex color code used to set the desired trim color on submitted messages.                                                                |
-| `message`                 | Yes      |               | *valid message string*                                      | The (optionally) Markdown-formatted message to submit.                                                                                      |
-| `team`                    | No       | `unspecified` | *valid Microsoft Teams team name*                           | The name of the Team containing our target channel. If not specified, defaults to `unspecified`.                                            |
-| `title`                   | Yes      |               | *valid title string*                                        | The title for the message to submit.                                                                                                        |
-| `sender`                  | No       |               | *valid application or script name*                          | The (optional) sending application name or generator of the message this app will attempt to deliver.                                       |
-| `url`                     | Yes      |               | [*valid Microsoft Office 365 Webhook URL*](#webhook-urls)   | The Webhook URL provided by a pre-configured Connector.                                                                                     |
-| `target-url`              | No       |               | *valid comma-separated `url`, `description` pair* (limit 4) | The target URL and label (specified as comma separated pair) usually visible as a button towards the bottom of the Microsoft Teams message. |
-| `verbose`                 | No       | `false`       | `true`, `false`                                             | Whether detailed output should be shown after message submission success or failure                                                         |
-| `silent`                  | No       | `false`       | `true`, `false`                                             | Whether ANY output should be shown after message submission success or failure                                                              |
-| `convert-eol`             | No       | `false`       | `true`, `false`                                             | Whether messages with Windows, Mac and Linux newlines are updated to use break statements before message submission                         |
-| `disable-url-validation`  | No       | `false`       | `true`, `false`                                             | Whether webhook URL validation should be disabled. Useful when submitting generated JSON payloads to a service like <https://httpbin.org/>. |
-| `ignore-invalid-response` | No       | `false`       | `true`, `false`                                             | Whether an invalid response from remote endpoint should be ignored. This is expected if submitting a message to a non-standard webhook URL. |
-| `retries`                 | No       | `2`           | *positive whole number*                                     | The number of attempts that this application will make to deliver messages before giving up.                                                |
-| `retries-delay`           | No       | `2`           | *positive whole number*                                     | The number of seconds that this application will wait before making another delivery attempt.                                               |
+| Flag                      | Required | Default       | Possible                                                    | Description                                                                                                                                                |
+| ------------------------- | -------- | ------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `h`, `help`               | No       | N/A           | N/A                                                         | Display Help; show available flags.                                                                                                                        |
+| `v`, `version`            | No       | `false`       | `true`, `false`                                             | Whether to display application version and then immediately exit application.                                                                              |
+| `channel`                 | No       | `unspecified` | *valid Microsoft Teams channel name*                        | The target channel where we will send a message. If not specified, defaults to `unspecified`.                                                              |
+| `color`                   | No       | `#832561`     | *valid hex color code with leading `#`*                     | The hex color code used to set the desired trim color on submitted messages.                                                                               |
+| `message`                 | Yes      |               | *valid message string*                                      | The (optionally) Markdown-formatted message to submit.                                                                                                     |
+| `team`                    | No       | `unspecified` | *valid Microsoft Teams team name*                           | The name of the Team containing our target channel. If not specified, defaults to `unspecified`.                                                           |
+| `title`                   | Yes      |               | *valid title string*                                        | The title for the message to submit.                                                                                                                       |
+| `sender`                  | No       |               | *valid application or script name*                          | The (optional) sending application name or generator of the message this app will attempt to deliver.                                                      |
+| `url`                     | Yes      |               | [*valid Microsoft Office 365 Webhook URL*](#webhook-urls)   | The Webhook URL provided by a pre-configured Connector.                                                                                                    |
+| `target-url`              | No       |               | *valid comma-separated `url`, `description` pair* (limit 4) | The target URL and label (specified as comma separated pair) usually visible as a button towards the bottom of the Microsoft Teams message.                |
+| `verbose`                 | No       | `false`       | `true`, `false`                                             | Whether detailed output should be shown after message submission success or failure                                                                        |
+| `silent`                  | No       | `false`       | `true`, `false`                                             | Whether ANY output should be shown after message submission success or failure                                                                             |
+| `convert-eol`             | No       | `false`       | `true`, `false`                                             | Whether messages with Windows, Mac and Linux newlines are updated to use break statements before message submission                                        |
+| `disable-url-validation`  | No       | `false`       | `true`, `false`                                             | Whether webhook URL validation should be disabled. Useful when submitting generated JSON payloads to a service like <https://httpbin.org/>.                |
+| `ignore-invalid-response` | No       | `false`       | `true`, `false`                                             | Whether an invalid response from remote endpoint should be ignored. This is expected if submitting a message to a non-standard webhook URL.                |
+| `retries`                 | No       | `2`           | *positive whole number*                                     | The number of attempts that this application will make to deliver messages before giving up.                                                               |
+| `retries-delay`           | No       | `2`           | *positive whole number*                                     | The number of seconds that this application will wait before making another delivery attempt.                                                              |
+| `user-mention`            | No       |               | *valid comma-separated `name`, `id` pair*                   | The DisplayName and ID of the recipient (specified as comma separated pair) for a user mention. Incompatible with `target-url`, `title` and `color` flags. |
 
 ## Examples
 
@@ -283,6 +286,41 @@ and on a single line (e.g., one-off via terminal or batch file):
 ```console
 ./send2teams.exe --silent --channel "Alerts" --team "Support" --message "Useful starting points" --title "Learn more about Go" --sender "Nagios" --color "#832561" --url "https://outlook.office.com/webhook/www@xxx/IncomingWebhook/yyy/zzz" --target-url "https://www.golang.org/, Go Homepage" --target-url "https://github.com/dariubs/GoBooks, Awesome Go Books"
 ```
+
+### User mention
+
+This example illustrates mentioning a user along with providing a brief
+message. The specific format is limited and subject to change in future
+releases.
+
+Incompatible with:
+
+- message title flag
+- target url flag
+- theme color flag
+
+The example, shown split over multiple lines for readability (e.g., shell
+script):
+
+```console
+./send2teams \
+  --silent \
+  --channel "Alerts" \
+  --team "Support" \
+  --message "System XYZ is down!" \
+  --user-mention "John Doe,jdoe@example.com"
+  --sender "Nagios" \
+  --url "https://outlook.office.com/webhook/www@xxx/IncomingWebhook/yyy/zzz"
+```
+
+and on a single line (e.g., one-off via terminal or batch file):
+
+```console
+./send2teams --silent --channel "Alerts" --team "Support" --message "System XYZ is down!" --user-mention "John Doe,jdoe@example.com" --sender "Nagios" --url "https://outlook.office.com/webhook/www@xxx/IncomingWebhook/yyy/zzz"
+```
+
+Remove the `-silent` flag in order to see pass or failure output, otherwise
+look at the exit code (`$?`) or Microsoft Teams to determine results.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ module github.com/atc0005/send2teams
 
 go 1.17
 
-require github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd
+require github.com/atc0005/go-teams-notify/v2 v2.7.0-alpha.1
 
 require github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd h1:2QMH6RkOoTIX7omCraj2duiNoYdzX2QetCzL/zEDpFU=
-github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd/go.mod h1:xo6GejLDHn3tWBA181F8LrllIL0xC1uRsRxq7YNXaaY=
+github.com/atc0005/go-teams-notify/v2 v2.7.0-alpha.1 h1:sMy2AYzVH9u8jNI/LCgsrj8+hL+2qPhLoevjP9EpjTE=
+github.com/atc0005/go-teams-notify/v2 v2.7.0-alpha.1/go.mod h1:xo6GejLDHn3tWBA181F8LrllIL0xC1uRsRxq7YNXaaY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -20,6 +20,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.BoolVar(&c.IgnoreInvalidResponse, "ignore-invalid-response", defaultIgnoreInvalidResponse, ignoreInvalidResponseFlagHelp)
 	flag.StringVar(&c.Team, "team", defaultTeamName, teamNameFlagHelp)
 	flag.Var(&c.TargetURLs, "target-url", targetURLFlagHelp)
+	flag.Var(&c.UserMentions, "user-mention", userMentionFlagHelp)
 	flag.StringVar(&c.Channel, "channel", defaultChannelName, channelNameFlagHelp)
 	flag.StringVar(&c.WebhookURL, "url", defaultWebhookURL, webhookURLFlagHelp)
 	flag.StringVar(&c.ThemeColor, "color", defaultMessageThemeColor, themeColorFlagHelp)

--- a/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
@@ -26,6 +26,30 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v2.6.1] - 2022-02-25
+
+### Changed
+
+- Dependencies
+  - `actions/setup-node`
+    - `v2.2.0` to `v3`
+
+- Linting
+  - (GH-131) Expand linting GitHub Actions Workflow to include `oldstable`,
+    `unstable` container images
+  - (GH-132) Switch Docker image source from Docker Hub to GitHub Container
+    Registry (GHCR)
+
+### Fixed
+
+- (GH-137) Missing doc comment for
+  `teamsClient.AddWebhookURLValidationPatterns()`
+- (GH-138) Missing doc comment for `teamsClient.ValidateWebhook()`
+- (GH-141) send.go:306:15: nilness: tautological condition: non-nil != nil
+  (govet)
+- (GH-144) Incorrect field referenced in error message for
+  `MessageCardSection.AddFact()`
+
 ## [v2.6.0] - 2021-07-09
 
 ### Added
@@ -388,7 +412,8 @@ The following types of changes will be recorded in this file:
 
 - add initial functionality of sending messages to MS Teams channel
 
-[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.6.1...HEAD
+[v2.6.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.6.1
 [v2.6.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.6.0
 [v2.5.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.5.0
 [v2.4.2]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.4.2

--- a/vendor/github.com/atc0005/go-teams-notify/v2/README.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 # go-teams-notify
 
-A package to send messages to Microsoft Teams (channels)
+A package to send messages to a Microsoft Teams channel.
 
 [![Latest release][githubtag-image]][githubtag-url]
 [![Go Reference][goref-image]][goref-url]
@@ -27,6 +27,7 @@ A package to send messages to Microsoft Teams (channels)
     - [How to create a webhook URL (Connector)](#how-to-create-a-webhook-url-connector)
   - [Examples](#examples)
     - [Basic](#basic)
+    - [User Mention](#user-mention)
     - [Set custom user agent](#set-custom-user-agent)
     - [Add an Action](#add-an-action)
     - [Disable webhook URL prefix validation](#disable-webhook-url-prefix-validation)
@@ -59,6 +60,7 @@ information.
     `Facts`) and/or externally hosted images. or images (hosted externally)
 - Support for [`Actions`][msgcard-ref-actions], allowing users to take quick
   actions within Microsoft Teams
+- Support for [user mentions][botapi-user-mentions] (limited)
 - Configurable validation of webhook URLs
   - enabled by default, attempts to match most common known webhook URL
     patterns
@@ -70,8 +72,6 @@ information.
     validation behavior
 - Configurable timeouts
 - Configurable retry support
-- Support for overriding the default `http.Client`
-- Support for overriding default project-specific user agent
 
 ## Project Status
 
@@ -187,6 +187,12 @@ This is an example of a simple client application which uses this library.
 
 File: [basic](./examples/basic/main.go)
 
+#### User Mention
+
+This example illustrates the use of a user mention.
+
+File: [basic](./examples/user-mention/main.go)
+
 #### Set custom user agent
 
 This example illustrates setting a custom user agent.
@@ -250,3 +256,5 @@ using either this library or the original project.
 
 [msgcard-ref]: <https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference>
 [msgcard-ref-actions]: <https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions>
+
+[botapi-user-mentions]: <https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations?tabs=json#work-with-mentions>

--- a/vendor/github.com/atc0005/go-teams-notify/v2/botapi/botapi.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/botapi/botapi.go
@@ -1,0 +1,350 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package botapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// MessageType is the type for a BotAPI Message.
+	MessageType string = "message"
+
+	// MentionType is the type for a user mention for a BotAPI Message.
+	MentionType string = "mention"
+
+	// MentionTextFormatTemplate is the expected format of the Mention.Text
+	// field value.
+	MentionTextFormatTemplate string = "<at>%s</at>"
+)
+
+var (
+	// ErrInvalidType indicates that an invalid type was specified.
+	ErrInvalidType = errors.New("invalid type value")
+
+	// ErrInvalidFieldValue indicates that an invalid value was specified.
+	ErrInvalidFieldValue = errors.New("invalid field value")
+
+	// ErrMissingValue indicates that an expected value was missing.
+	ErrMissingValue = errors.New("missing expected value")
+)
+
+// Message is a minimal representation of the object used to mention one or
+// more users in a Teams channel.
+//
+// https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations?tabs=json#add-mentions-to-your-messages
+type Message struct {
+	// Type is required; must be set to "message".
+	Type string `json:"type"`
+
+	// Text is required; mostly freeform content, but testing shows that the
+	// "<at>Some User</at>" string (composed of Display Name value) is
+	// required by Microsoft Teams for each Mention in the entities
+	// collection.
+	Text string `json:"text"`
+
+	// Entities is required; a collection of Mention values, one per mentioned
+	// individual.
+	Entities []Mention `json:"entities"`
+
+	// payload is a prepared Message in JSON format for submission or pretty
+	// printing.
+	payload *bytes.Buffer `json:"-"`
+}
+
+// Mention represents a mention in the message for a specific user.
+type Mention struct {
+	// Type is required; must be set to "mention".
+	Type string `json:"type"`
+
+	// Text must match a portion of the message text field. If it does not,
+	// the mention is ignored.
+	//
+	// Brief testing indicates that this needs to wrap a name/value in <at>NAME
+	// HERE</at> tags.
+	Text string `json:"text"`
+
+	// Mentioned represents a user that is mentioned.
+	Mentioned Mentioned `json:"mentioned"`
+}
+
+// Mentioned represents the user id and name of a user that is mentioned.
+type Mentioned struct {
+	// ID is the unique identifier for a user that is mentioned. This value
+	// can be an object ID (e.g., 5e8b0f4d-2cd4-4e17-9467-b0f6a5c0c4d0) or a
+	// UserPrincipalName (e.g., NewUser@contoso.onmicrosoft.com).
+	ID string `json:"id"`
+
+	// Name is the DisplayName of the user mentioned.
+	Name string `json:"name"`
+}
+
+// NewMessage creates a new Message with required fields predefined.
+func NewMessage() *Message {
+	return &Message{
+		Type: MessageType,
+	}
+}
+
+// NewMessage creates a new Message using provided text with required fields
+// predefined.
+// func NewMessage(text string) *Message {
+// 	return &Message{
+// 		Type: MessageType,
+// 		Text: text,
+// 	}
+// }
+
+// AddText adds given text to the message for delivery. If specified, this
+// method prepends given text instead of appending it.
+//
+// The caller may directly write to the exported Message Text field in order
+// to overwrite existing Message text. The caller then takes responsibility
+// for ensuring that any user mention placeholders are explicitly provided for
+// the Message Text field in order to comply with API requirements.
+// func (m *Message) AddText(text string, prepend bool) *Message {
+// 	switch {
+// 	case strings.TrimSpace(text) == "":
+// 		// Passing an empty text string is effectively a NOOP.
+// 	case prepend:
+// 		m.Text = text + " " + m.Text
+// 	default:
+// 		m.Text += text
+// 	}
+//
+// 	return m
+// }
+
+// AddText appends given text to the message for delivery.
+//
+// As an alternative to using this method, the caller may directly write to
+// the exported Message Text field. If opting to use this approach, care
+// should be taken by the caller to retain any previously added mention
+// placeholders.
+func (m *Message) AddText(text string) *Message {
+	switch {
+	case strings.TrimSpace(text) == "":
+		// Passing an empty text string is effectively a NOOP.
+	default:
+		m.Text += text
+	}
+
+	return m
+}
+
+// PrettyPrint returns a formatted JSON payload of the Message if the
+// Prepare() method has been called, or an empty string otherwise.
+func (m *Message) PrettyPrint() string {
+	if m.payload != nil {
+		var prettyJSON bytes.Buffer
+
+		// Validation is handled by the Message.Prepare() method.
+		_ = json.Indent(&prettyJSON, m.payload.Bytes(), "", "\t")
+
+		return prettyJSON.String()
+	}
+
+	return ""
+}
+
+// Validate performs basic validation of required field values.
+func (m Message) Validate() error {
+	if m.Text == "" {
+		return fmt.Errorf(
+			"required Text field is empty: %w",
+			ErrInvalidFieldValue,
+		)
+	}
+
+	if m.Type != MessageType {
+		return fmt.Errorf(
+			"got %s; wanted %s: %w",
+			m.Type,
+			MessageType,
+			ErrInvalidType,
+		)
+	}
+
+	// If we have any recorded user mentions, check each of them.
+	if len(m.Entities) > 0 {
+		for _, mention := range m.Entities {
+			if err := mention.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Validate performs basic validation of required field values.
+func (m Mention) Validate() error {
+	if m.Type != MentionType {
+		return fmt.Errorf(
+			"got %s; wanted %s: %w",
+			m.Type,
+			MentionType,
+			ErrInvalidType,
+		)
+	}
+
+	if m.Text == "" {
+		return fmt.Errorf(
+			"required Text field is empty: %w",
+			ErrInvalidFieldValue,
+		)
+	}
+
+	if m.Mentioned.ID == "" {
+		return fmt.Errorf(
+			"required ID field is empty: %w",
+			ErrInvalidFieldValue,
+		)
+	}
+
+	if m.Mentioned.Name == "" {
+		return fmt.Errorf(
+			"required Name field is empty: %w",
+			ErrInvalidFieldValue,
+		)
+	}
+
+	return nil
+}
+
+// AddMention adds one or many Mention values to a Message.
+//
+// If specified, the Text field from each given Mention is prepended to the
+// Text field of the Message in order to satisfy the API Message format
+// requirements. If specified, the given separator is used, otherwise a space
+// is assumed.
+//
+// If the caller opts to not update the Message Text field when adding a
+// Mention, the caller is then responsible for ensuring that the Message Text
+// field contains a valid match for each mentioned user.
+//
+// NOTE: Testing indicates that the expected format matches the DisplayName
+// field for the user (e.g., "John Doe" instead of "John" or "Doe" or a custom
+// format).
+func (m *Message) AddMention(prependToText bool, separator string, mentions ...Mention) error {
+	if len(mentions) == 0 {
+		return fmt.Errorf(
+			"func AddMention: missing value: %w",
+			ErrMissingValue,
+		)
+	}
+
+	for _, mention := range mentions {
+		if err := mention.Validate(); err != nil {
+			return fmt.Errorf(
+				"func AddMention: validation failed: %w",
+				err,
+			)
+		}
+
+		m.Entities = append(m.Entities, mention)
+
+		// Fallback to single space separator if user didn't specify one.
+		if separator == "" {
+			separator = " "
+		}
+
+		if prependToText {
+			m.Text = mention.Text + separator + m.Text
+		}
+	}
+
+	return nil
+}
+
+// Mention creates a new user Mention to be included in the Message entities
+// collection.
+//
+// This method receives a user's DisplayName, ID and a boolean value used to
+// indicate whether a leading text string of the format "<at>John Doe</at>"
+// (i.e., a user "mention") should be prepended to the Message Text field.
+//
+// If the caller opts to not have this method update the Message Text field,
+// then the caller will need to ensure that the Message Text field is updated
+// to include a matching pattern for every Mention that is included in the
+// entities collection for the Message.
+//
+// NOTE: Brief testing suggests that the user's display name (e.g., "John
+// Doe") is required instead of a firstname (e.g., "John"), lastname ("Doe")
+// or custom value (e.g., "JD") is required.
+//
+// The ID value can be an object ID (e.g.,
+// 5e8b0f4d-2cd4-4e17-9467-b0f6a5c0c4d0) or a UserPrincipalName (e.g.,
+// NewUser@contoso.onmicrosoft.com).
+func (m *Message) Mention(displayName string, id string, prependToText bool) error {
+	switch {
+	case displayName == "":
+		return fmt.Errorf(
+			"func Mention: required name argument is empty: %w",
+			ErrMissingValue,
+		)
+
+	case id == "":
+		return fmt.Errorf(
+			"func Mention: required id argument is empty: %w",
+			ErrMissingValue,
+		)
+
+	default:
+		mention := Mention{
+			Type: MentionType,
+			// Text: textVal,
+			Text: fmt.Sprintf(MentionTextFormatTemplate, displayName),
+			Mentioned: Mentioned{
+				ID:   id,
+				Name: displayName,
+			},
+		}
+
+		m.Entities = append(m.Entities, mention)
+
+		if prependToText {
+			m.Text = mention.Text + " " + m.Text
+		}
+	}
+
+	return nil
+}
+
+// Prepare handles tasks needed to prepare a given Message for delivery to an
+// endpoint. If specified, tasks are repeated regardless of whether a previous
+// Prepare call was made. Validation should be performed by the caller prior
+// to calling this method.
+func (m *Message) Prepare(recreate bool) error {
+	if m.payload != nil && !recreate {
+		return nil
+	}
+
+	jsonMessage, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to prepare message: %w",
+			err,
+		)
+	}
+
+	m.payload = bytes.NewBuffer(jsonMessage)
+
+	return nil
+}
+
+// Payload returns the prepared Message payload. The caller should call
+// Prepare() prior to calling this method, results are undefined otherwise.
+func (m *Message) Payload() io.Reader {
+	return m.payload
+}

--- a/vendor/github.com/atc0005/go-teams-notify/v2/botapi/doc.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/botapi/doc.go
@@ -1,0 +1,26 @@
+/*
+Package botapi is intended to provide limited support for adding user mention
+functionality to messages sent to a Microsoft Teams channel.
+
+This package is currently a work-in-progress; when complete, this package will
+provide support for generating a message equivalent to the example below,
+contributed by @ghokun via
+https://github.com/atc0005/go-teams-notify/issues/127.
+
+curl -X POST -H "Content-type: application/json" -d '{
+    "type": "message",
+    "text": "Hey <at>Some User</at> check out this message",
+    "entities": [
+        {
+            "type":"mention",
+            "mentioned":{
+                "id":"some.user@company.com",
+                "name":"Some User"
+            },
+            "text": "<at>Some User</at>"
+        }
+    ]
+}' <webhook_url>
+
+*/
+package botapi

--- a/vendor/github.com/atc0005/go-teams-notify/v2/doc.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/doc.go
@@ -7,7 +7,7 @@
 
 /*
 
-Package goteamsnotify is used to send messages to Microsoft Teams (channels)
+Package goteamsnotify is used to send messages to a Microsoft Teams channel.
 
 PROJECT HOME
 
@@ -27,6 +27,8 @@ FEATURES
 
 • Support for Actions, allowing users to take quick actions within Microsoft Teams
 
+• Support for user mentions (limited)
+
 • Configurable validation
 
 • Configurable timeouts
@@ -36,7 +38,6 @@ FEATURES
 • Support for overriding the default http.Client
 
 • Support for overriding the default project-specific user agent
-
 
 USAGE
 

--- a/vendor/github.com/atc0005/go-teams-notify/v2/messagecard/doc.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/messagecard/doc.go
@@ -1,0 +1,5 @@
+/*
+Package messagecard provides support for the legacy MessageCard format in
+order to generate Microsoft Teams messages.
+*/
+package messagecard

--- a/vendor/github.com/atc0005/go-teams-notify/v2/messagecard/messagecard.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/messagecard/messagecard.go
@@ -6,7 +6,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
-package goteamsnotify
+package messagecard
 
 import (
 	"bytes"
@@ -20,72 +20,48 @@ import (
 const (
 	// PotentialActionOpenURIType is the type that must be used for OpenUri
 	// potential action.
-	//
-	// Deprecated: use messagecard.PotentialActionOpenURIType instead.
 	PotentialActionOpenURIType = "OpenUri"
 
 	// PotentialActionHTTPPostType is the type that must be used for HttpPOST
 	// potential action.
-	//
-	// Deprecated: use messagecard.PotentialActionHTTPPostType instead.
 	PotentialActionHTTPPostType = "HttpPOST"
 
 	// PotentialActionActionCardType is the type that must be used for
 	// ActionCard potential action.
-	//
-	// Deprecated: use messagecard.PotentialActionActionCardType instead.
 	PotentialActionActionCardType = "ActionCard"
 
 	// PotentialActionInvokeAddInCommandType is the type that must be used for
 	// InvokeAddInCommand potential action.
-	//
-	// Deprecated: use messagecard.PotentialActionInvokeAddInCommandType
-	// instead.
 	PotentialActionInvokeAddInCommandType = "InvokeAddInCommand"
 
 	// PotentialActionActionCardInputTextInputType is the type that must be
 	// used for ActionCard TextInput type.
-	//
-	// Deprecated: use messagecard.PotentialActionActionCardInputTextInputType
-	// instead.
 	PotentialActionActionCardInputTextInputType = "TextInput"
 
 	// PotentialActionActionCardInputDateInputType is the type that must be
 	// used for ActionCard DateInput type.
-	//
-	// Deprecated: use messagecard.PotentialActionActionCardInputDateInputType
-	// instead.
 	PotentialActionActionCardInputDateInputType = "DateInput"
 
-	// PotentialActionActionCardInputMultichoiceInput is the type that must be
-	// used for ActionCard MultichoiceInput type.
-	//
-	// Deprecated: use
-	// messagecard.PotentialActionActionCardInputMultichoiceInputType instead.
-	PotentialActionActionCardInputMultichoiceInput = "MultichoiceInput"
+	// PotentialActionActionCardInputMultichoiceInputType is the type that
+	// must be used for ActionCard MultichoiceInput type.
+	PotentialActionActionCardInputMultichoiceInputType = "MultichoiceInput"
 )
 
 // PotentialActionMaxSupported is the maximum number of actions allowed in a
-// MessageCardPotentialAction collection.
+// PotentialAction collection.
 // https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions
-//
-// Deprecated: use messagecard.PotentialActionMaxSupported instead.
 const PotentialActionMaxSupported = 4
 
 // ErrPotentialActionsLimitReached indicates that the maximum supported number
 // of potentialAction collection values has been reached for either a
-// MessageCard or a MessageCardSection.
-//
-// Deprecated: use messagecard.ErrPotentialActionsLimitReached instead.
+// MessageCard or a Section.
 var ErrPotentialActionsLimitReached = errors.New("potential actions collection limit reached")
 
-// MessageCardPotentialAction represents potential actions an user can do in a
+// PotentialAction represents potential actions an user can do in a
 // message card. See
 // https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions
 // for more information.
-//
-// Deprecated: use messagecard.PotentialAction instead.
-type MessageCardPotentialAction struct {
+type PotentialAction struct {
 	// Type of the potential action. Can be OpenUri, HttpPOST, ActionCard or
 	// InvokeAddInCommand.
 	Type string `json:"@type"`
@@ -94,36 +70,32 @@ type MessageCardPotentialAction struct {
 	// action.
 	Name string `json:"name"`
 
-	// MessageCardPotentialActionOpenURI is a set of options for openUri
+	// PotentialActionOpenURI is a set of options for openUri
 	// potential action.
-	MessageCardPotentialActionOpenURI
+	PotentialActionOpenURI
 
-	// MessageCardPotentialActionHTTPPOST is a set of options for httpPOST
+	// PotentialActionHTTPPOST is a set of options for httpPOST
 	// potential action.
-	MessageCardPotentialActionHTTPPOST
+	PotentialActionHTTPPOST
 
-	// MessageCardPotentialActionActionCard is a set of options for actionCard
+	// PotentialActionActionCard is a set of options for actionCard
 	// potential action.
-	MessageCardPotentialActionActionCard
+	PotentialActionActionCard
 
-	// MessageCardPotentialActionInvokeAddInCommand is a set of options for
+	// PotentialActionInvokeAddInCommand is a set of options for
 	// invokeAddInCommand potential action.
-	MessageCardPotentialActionInvokeAddInCommand
+	PotentialActionInvokeAddInCommand
 }
 
-// MessageCardPotentialActionOpenURI represents a OpenUri potential action.
-//
-// Deprecated: use messagecard.PotentialActionOpenURI instead.
-type MessageCardPotentialActionOpenURI struct {
+// PotentialActionOpenURI represents a OpenUri potential action.
+type PotentialActionOpenURI struct {
 	// Targets is a collection of name/value pairs that defines one URI per
 	// target operating system. Only used for OpenUri action type.
-	Targets []MessageCardPotentialActionOpenURITarget `json:"targets,omitempty"`
+	Targets []PotentialActionOpenURITarget `json:"targets,omitempty"`
 }
 
-// MessageCardPotentialActionHTTPPOST represents a HttpPOST potential action.
-//
-// Deprecated: use messagecard.PotentialActionHTTPPOST instead.
-type MessageCardPotentialActionHTTPPOST struct {
+// PotentialActionHTTPPOST represents a HttpPOST potential action.
+type PotentialActionHTTPPOST struct {
 	// Target defines the URL endpoint of the service that implements the
 	// action. Only used for HttpPOST action type.
 	Target string `json:"target,omitempty"`
@@ -131,7 +103,7 @@ type MessageCardPotentialActionHTTPPOST struct {
 	// Headers is a collection of MessageCardPotentialActionHeader objects
 	// representing a set of HTTP headers that will be emitted when sending
 	// the POST request to the target URL. Only used for HttpPOST action type.
-	Headers []MessageCardPotentialActionHTTPPOSTHeader `json:"headers,omitempty"`
+	Headers []PotentialActionHTTPPOSTHeader `json:"headers,omitempty"`
 
 	// Body is the body of the POST request. Only used for HttpPOST action
 	// type.
@@ -142,27 +114,21 @@ type MessageCardPotentialActionHTTPPOST struct {
 	BodyContentType string `json:"bodyContentType,omitempty"`
 }
 
-// MessageCardPotentialActionActionCard represents an actionCard potential
+// PotentialActionActionCard represents an actionCard potential
 // action.
-//
-// Deprecated: use messagecard.PotentialActionActionCard instead.
-type MessageCardPotentialActionActionCard struct {
+type PotentialActionActionCard struct {
 	// Inputs is a collection of inputs an user can provide before processing
 	// the actions. Only used for ActionCard action type. Three types of
 	// inputs are available: TextInput, DateInput and MultichoiceInput
-	Inputs []MessageCardPotentialActionActionCardInput `json:"inputs,omitempty"`
+	Inputs []PotentialActionActionCardInput `json:"inputs,omitempty"`
 
 	// Actions are the available actions. Only used for ActionCard action
 	// type.
-	Actions []MessageCardPotentialActionActionCardAction `json:"actions,omitempty"`
+	Actions []PotentialActionActionCardAction `json:"actions,omitempty"`
 }
 
-// MessageCardPotentialActionActionCardAction is used for configuring
-// ActionCard actions.
-//
-// Deprecated: use messagecard.PotentialActionActionCardAction
-// instead.
-type MessageCardPotentialActionActionCardAction struct {
+// PotentialActionActionCardAction is used for configuring ActionCard actions
+type PotentialActionActionCardAction struct {
 	// Type of the action. Can be OpenUri, HttpPOST, ActionCard or
 	// InvokeAddInCommand.
 	Type string `json:"@type"`
@@ -171,21 +137,18 @@ type MessageCardPotentialActionActionCardAction struct {
 	// action.
 	Name string `json:"name"`
 
-	// MessageCardPotentialActionOpenURI is used to specify a openUri action
+	// PotentialActionOpenURI is used to specify a openUri action
 	// card's action.
-	MessageCardPotentialActionOpenURI
+	PotentialActionOpenURI
 
-	// MessageCardPotentialActionHTTPPOST is used to specify a httpPOST action
+	// PotentialActionHTTPPOST is used to specify a httpPOST action
 	// card's action.
-	MessageCardPotentialActionHTTPPOST
+	PotentialActionHTTPPOST
 }
 
-// MessageCardPotentialActionInvokeAddInCommand represents an
-// invokeAddInCommand potential action.
-//
-// Deprecated: use messagecard.PotentialActionInvokeAddInCommand
-// instead.
-type MessageCardPotentialActionInvokeAddInCommand struct {
+// PotentialActionInvokeAddInCommand represents an invokeAddInCommand
+// potential action.
+type PotentialActionInvokeAddInCommand struct {
 	// AddInID specifies the add-in ID of the required add-in. Only used for
 	// InvokeAddInCommand action type.
 	AddInID string `json:"addInId,omitempty"`
@@ -203,12 +166,9 @@ type MessageCardPotentialActionInvokeAddInCommand struct {
 	InitializationContext interface{} `json:"initializationContext,omitempty"`
 }
 
-// MessageCardPotentialActionOpenURITarget is used for OpenUri action type.
+// PotentialActionOpenURITarget is used for OpenUri action type.
 // It defines one URI per target operating system.
-//
-// Deprecated: use messagecard.PotentialActionOpenURITarget
-// instead.
-type MessageCardPotentialActionOpenURITarget struct {
+type PotentialActionOpenURITarget struct {
 	// OS defines the operating system the target uri refers to. Supported
 	// operating system values are default, windows, iOS and android. The
 	// default operating system will in most cases simply open the URI in a
@@ -219,12 +179,8 @@ type MessageCardPotentialActionOpenURITarget struct {
 	URI string `json:"uri,omitempty"`
 }
 
-// MessageCardPotentialActionHTTPPOSTHeader defines a HTTP header used for
-// HttpPOST action type.
-//
-// Deprecated: use messagecard.PotentialActionHTTPPOSTHeader
-// instead.
-type MessageCardPotentialActionHTTPPOSTHeader struct {
+// PotentialActionHTTPPOSTHeader defines a HTTP header used for HttpPOST action type.
+type PotentialActionHTTPPOSTHeader struct {
 	// Name is the header name.
 	Name string `json:"name,omitempty"`
 
@@ -232,11 +188,8 @@ type MessageCardPotentialActionHTTPPOSTHeader struct {
 	Value string `json:"value,omitempty"`
 }
 
-// MessageCardPotentialActionActionCardInput represents an ActionCard input.
-//
-// Deprecated: use messagecard.PotentialActionActionCardInput
-// instead.
-type MessageCardPotentialActionActionCardInput struct {
+// PotentialActionActionCardInput represents an ActionCard input.
+type PotentialActionActionCardInput struct {
 	// Type of the ActionCard input.
 	// Must be either TextInput, DateInput or MultichoiceInput
 	Type string `json:"@type"`
@@ -255,15 +208,15 @@ type MessageCardPotentialActionActionCardInput struct {
 
 	// MessageCardPotentialActionInputMultichoiceInput must be defined for
 	// MultichoiceInput input type.
-	MessageCardPotentialActionActionCardInputMultichoiceInput
+	PotentialActionActionCardInputMultichoiceInput
 
 	// MessageCardPotentialActionInputTextInput must be defined for InputText
 	// input type.
-	MessageCardPotentialActionActionCardInputTextInput
+	PotentialActionActionCardInputTextInput
 
 	// MessageCardPotentialActionInputDateInput must be defined for DateInput
 	// input type.
-	MessageCardPotentialActionActionCardInputDateInput
+	PotentialActionActionCardInputDateInput
 
 	// IsRequired indicates whether users are required to type a value before
 	// they are able to take an action that would take the value of the input
@@ -271,12 +224,9 @@ type MessageCardPotentialActionActionCardInput struct {
 	IsRequired bool `json:"isRequired,omitempty"`
 }
 
-// MessageCardPotentialActionActionCardInputTextInput represents a TextInput
+// PotentialActionActionCardInputTextInput represents a TextInput
 // input used for potential action.
-//
-// Deprecated: use messagecard.PotentialActionActionCardInputTextInput
-// instead.
-type MessageCardPotentialActionActionCardInputTextInput struct {
+type PotentialActionActionCardInputTextInput struct {
 	// MaxLength indicates the maximum number of characters that can be
 	// entered.
 	MaxLength int `json:"maxLength,omitempty"`
@@ -286,12 +236,9 @@ type MessageCardPotentialActionActionCardInputTextInput struct {
 	IsMultiline bool `json:"isMultiline,omitempty"`
 }
 
-// MessageCardPotentialActionActionCardInputMultichoiceInput represents a
+// PotentialActionActionCardInputMultichoiceInput represents a
 // MultichoiceInput input used for potential action.
-//
-// Deprecated: use messagecard.PotentialActionActionCardInputMultichoiceInput
-// instead.
-type MessageCardPotentialActionActionCardInputMultichoiceInput struct {
+type PotentialActionActionCardInputMultichoiceInput struct {
 	// Choices defines the values that can be selected for the multichoice
 	// input.
 	Choices []struct {
@@ -311,22 +258,17 @@ type MessageCardPotentialActionActionCardInputMultichoiceInput struct {
 	IsMultiSelect bool `json:"isMultiSelect,omitempty"`
 }
 
-// MessageCardPotentialActionActionCardInputDateInput represents a DateInput
+// PotentialActionActionCardInputDateInput represents a DateInput
 // input used for potential action.
-//
-// Deprecated: use messagecard.PotentialActionActionCardInputDateInput
-// instead.
-type MessageCardPotentialActionActionCardInputDateInput struct {
+type PotentialActionActionCardInputDateInput struct {
 	// IncludeTime indicates whether the date input should allow for the
 	// selection of a time in addition to the date.
 	IncludeTime bool `json:"includeTime,omitempty"`
 }
 
-// MessageCardSectionFact represents a section fact entry that is usually
-// displayed in a two-column key/value format.
-//
-// Deprecated: use messagecard.SectionFact instead.
-type MessageCardSectionFact struct {
+// SectionFact represents a section fact entry that is usually displayed in a
+// two-column key/value format.
+type SectionFact struct {
 
 	// Name is the key for an associated value in a key/value pair
 	Name string `json:"name"`
@@ -335,11 +277,9 @@ type MessageCardSectionFact struct {
 	Value string `json:"value"`
 }
 
-// MessageCardSectionImage represents an image as used by the heroImage and
-// images properties of a section.
-//
-// Deprecated: use messagecard.SectionImage instead.
-type MessageCardSectionImage struct {
+// SectionImage represents an image as used by the heroImage and images
+// properties of a section.
+type SectionImage struct {
 
 	// Image is the URL to the image.
 	Image string `json:"image"`
@@ -350,10 +290,8 @@ type MessageCardSectionImage struct {
 	Title string `json:"title"`
 }
 
-// MessageCardSection represents a section to include in a message card.
-//
-// Deprecated: use messagecard.Section instead.
-type MessageCardSection struct {
+// Section represents a section to include in a message card.
+type Section struct {
 	// Title is the title property of a section. This property is displayed
 	// in a font that stands out, while not as prominent as the card's title.
 	// It is meant to introduce the section and summarize its content,
@@ -397,11 +335,11 @@ type MessageCardSection struct {
 	// https://github.com/golang/go/issues/11939
 	// https://stackoverflow.com/questions/18088294/how-to-not-marshal-an-empty-struct-into-json-with-go
 	// https://stackoverflow.com/questions/33447334/golang-json-marshal-how-to-omit-empty-nested-struct
-	HeroImage *MessageCardSectionImage `json:"heroImage,omitempty"`
+	HeroImage *SectionImage `json:"heroImage,omitempty"`
 
-	// Facts is a collection of MessageCardSectionFact values. A section entry
+	// Facts is a collection of SectionFact values. A section entry
 	// usually is displayed in a two-column key/value format.
-	Facts []MessageCardSectionFact `json:"facts,omitempty"`
+	Facts []SectionFact `json:"facts,omitempty"`
 
 	// Images is a property that allows for the inclusion of a photo gallery
 	// inside a section.
@@ -410,11 +348,11 @@ type MessageCardSection struct {
 	// https://github.com/golang/go/issues/11939
 	// https://stackoverflow.com/questions/18088294/how-to-not-marshal-an-empty-struct-into-json-with-go
 	// https://stackoverflow.com/questions/33447334/golang-json-marshal-how-to-omit-empty-nested-struct
-	Images []*MessageCardSectionImage `json:"images,omitempty"`
+	Images []*SectionImage `json:"images,omitempty"`
 
-	// PotentialActions is a collection of actions for a MessageCardSection.
+	// PotentialActions is a collection of actions for a Section.
 	// This is separate from the actions collection for the MessageCard.
-	PotentialActions []*MessageCardPotentialAction `json:"potentialAction,omitempty"`
+	PotentialActions []*PotentialAction `json:"potentialAction,omitempty"`
 
 	// Markdown represents a toggle to enable or disable Markdown formatting.
 	// By default, all text fields in a card and its sections can be formatted
@@ -430,8 +368,6 @@ type MessageCardSection struct {
 
 // MessageCard represents a legacy actionable message card used via Office 365
 // or Microsoft Teams connectors.
-//
-// Deprecated: use messagecard.MessageCard instead.
 type MessageCard struct {
 	// Required; must be set to "MessageCard"
 	Type string `json:"@type"`
@@ -466,21 +402,21 @@ type MessageCard struct {
 	ValidateFunc func() error `json:"-"`
 
 	// Sections is a collection of sections to include in the card.
-	Sections []*MessageCardSection `json:"sections,omitempty"`
+	Sections []*Section `json:"sections,omitempty"`
 
 	// PotentialActions is a collection of actions for a MessageCard.
-	PotentialActions []*MessageCardPotentialAction `json:"potentialAction,omitempty"`
+	PotentialActions []*PotentialAction `json:"potentialAction,omitempty"`
 
 	// payload is a prepared MessageCard in JSON format for submission or
 	// pretty printing.
 	payload *bytes.Buffer `json:"-"`
 }
 
-// validatePotentialAction inspects the given *MessageCardPotentialAction
+// validatePotentialAction inspects the given *PotentialAction
 // and returns an error if a value is missing or not known.
-func validatePotentialAction(pa *MessageCardPotentialAction) error {
+func validatePotentialAction(pa *PotentialAction) error {
 	if pa == nil {
-		return fmt.Errorf("nil MessageCardPotentialAction received")
+		return fmt.Errorf("nil PotentialAction received")
 	}
 
 	switch pa.Type {
@@ -494,27 +430,21 @@ func validatePotentialAction(pa *MessageCardPotentialAction) error {
 	}
 
 	if pa.Name == "" {
-		return fmt.Errorf("missing name value for MessageCardPotentialAction")
+		return fmt.Errorf("missing name value for PotentialAction")
 	}
 
 	return nil
 }
 
-// addPotentialAction adds one or many MessageCardPotentialAction values to a
+// addPotentialAction adds one or many PotentialAction values to a
 // PotentialActions collection.
-func addPotentialAction(collection *[]*MessageCardPotentialAction, actions ...*MessageCardPotentialAction) error {
+func addPotentialAction(collection *[]*PotentialAction, actions ...*PotentialAction) error {
 	for _, a := range actions {
-		logger.Printf("addPotentialAction: MessageCardPotentialAction received: %+v\n", a)
-
 		if err := validatePotentialAction(a); err != nil {
-			logger.Printf("addPotentialAction: validation failed: %v", err)
-
 			return err
 		}
 
 		if len(*collection) > PotentialActionMaxSupported {
-			logger.Printf("addPotentialAction: failed to add potential action: %v", ErrPotentialActionsLimitReached.Error())
-
 			return fmt.Errorf("func addPotentialAction: failed to add potential action: %w", ErrPotentialActionsLimitReached)
 		}
 
@@ -524,22 +454,17 @@ func addPotentialAction(collection *[]*MessageCardPotentialAction, actions ...*M
 	return nil
 }
 
-// AddSection adds one or many additional MessageCardSection values to a
-// MessageCard. Validation is performed to reject invalid values with an error
-// message.
-//
-// Deprecated: use (messagecard.MessageCard).AddSection instead.
-func (mc *MessageCard) AddSection(section ...*MessageCardSection) error {
+// AddSection adds one or many additional Section values to a MessageCard.
+// Validation is performed to reject invalid values with an error message.
+func (mc *MessageCard) AddSection(section ...*Section) error {
 	for _, s := range section {
-		logger.Printf("AddSection: MessageCardSection received: %+v\n", s)
-
 		// bail if a completely nil section provided
 		if s == nil {
-			return fmt.Errorf("func AddSection: nil MessageCardSection received")
+			return fmt.Errorf("func AddSection: nil Section received")
 		}
 
-		// Perform validation of all MessageCardSection fields in an effort to
-		// avoid adding a MessageCardSection with zero value fields. This is
+		// Perform validation of all Section fields in an effort to
+		// avoid adding a Section with zero value fields. This is
 		// done to avoid generating an empty sections JSON array since the
 		// Sections slice for the MessageCard type would technically not be at
 		// a zero value state. Due to this non-zero value state, the
@@ -562,29 +487,23 @@ func (mc *MessageCard) AddSection(section ...*MessageCardSection) error {
 		case s.Title != "":
 
 		default:
-			logger.Println("AddSection: No cases matched, all fields assumed to be at zero-value, skipping section")
 			return fmt.Errorf("all fields found to be at zero-value, skipping section")
 		}
 
-		logger.Println("AddSection: section contains at least one non-zero value, adding section")
 		mc.Sections = append(mc.Sections, s)
 	}
 
 	return nil
 }
 
-// AddPotentialAction adds one or many MessageCardPotentialAction values to a
+// AddPotentialAction adds one or many PotentialAction values to a
 // PotentialActions collection on a MessageCard.
-//
-// Deprecated: use (messagecard.MessageCard).AddPotentialAction instead.
-func (mc *MessageCard) AddPotentialAction(actions ...*MessageCardPotentialAction) error {
+func (mc *MessageCard) AddPotentialAction(actions ...*PotentialAction) error {
 	return addPotentialAction(&mc.PotentialActions, actions...)
 }
 
 // Validate validates a MessageCard calling ValidateFunc if defined,
 // otherwise, a default validation occurs.
-//
-// Deprecated: use (messagecard.MessageCard).Validate instead.
 func (mc *MessageCard) Validate() error {
 	if mc.ValidateFunc != nil {
 		return mc.ValidateFunc()
@@ -605,8 +524,6 @@ func (mc *MessageCard) Validate() error {
 // endpoint. If specified, tasks are repeated regardless of whether a previous
 // Prepare call was made. Validation should be performed by the caller prior
 // to calling this method.
-//
-// Deprecated: use (messagecard.MessageCard).Prepare instead.
 func (mc *MessageCard) Prepare(recreate bool) error {
 	if mc.payload != nil && !recreate {
 		return nil
@@ -624,16 +541,12 @@ func (mc *MessageCard) Prepare(recreate bool) error {
 
 // Payload returns the prepared MessageCard payload. The caller should call
 // Prepare() prior to calling this method, results are undefined otherwise.
-//
-// Deprecated: use (messagecard.MessageCard).Payload instead.
 func (mc *MessageCard) Payload() io.Reader {
 	return mc.payload
 }
 
 // PrettyPrint returns a formatted JSON payload of the MessageCard if the
 // Prepare() method has been called, or an empty string otherwise.
-//
-// Deprecated: use (messagecard.MessageCard).PrettyPrint instead.
 func (mc *MessageCard) PrettyPrint() string {
 	if mc.payload != nil {
 		var prettyJSON bytes.Buffer
@@ -647,14 +560,10 @@ func (mc *MessageCard) PrettyPrint() string {
 	return ""
 }
 
-// AddFact adds one or many additional MessageCardSectionFact values to a
-// MessageCardSection.
-//
-// Deprecated: use (messagecard.Section).AddFact instead.
-func (mcs *MessageCardSection) AddFact(fact ...MessageCardSectionFact) error {
+// AddFact adds one or many additional SectionFact values to a
+// Section
+func (mcs *Section) AddFact(fact ...SectionFact) error {
 	for _, f := range fact {
-		logger.Printf("AddFact: MessageCardSectionFact received: %+v\n", f)
-
 		if f.Name == "" {
 			return fmt.Errorf("empty Name field received for new fact: %+v", f)
 		}
@@ -664,18 +573,14 @@ func (mcs *MessageCardSection) AddFact(fact ...MessageCardSectionFact) error {
 		}
 	}
 
-	logger.Println("AddFact: section fact contains at least one non-zero value, adding section fact")
 	mcs.Facts = append(mcs.Facts, fact...)
 
 	return nil
 }
 
 // AddFactFromKeyValue accepts a key and slice of values and converts them to
-// MessageCardSectionFact values.
-//
-// Deprecated: use (messagecard.Section).AddFactFromKeyValue
-// instead.
-func (mcs *MessageCardSection) AddFactFromKeyValue(key string, values ...string) error {
+// SectionFact values
+func (mcs *Section) AddFactFromKeyValue(key string, values ...string) error {
 	// validate arguments
 
 	if key == "" {
@@ -686,14 +591,10 @@ func (mcs *MessageCardSection) AddFactFromKeyValue(key string, values ...string)
 		return errors.New("no values received for new fact")
 	}
 
-	fact := MessageCardSectionFact{
+	fact := SectionFact{
 		Name:  key,
 		Value: strings.Join(values, ", "),
 	}
-	// TODO: Explicitly define or use constructor?
-	// fact := NewMessageCardSectionFact()
-	// fact.Name = key
-	// fact.Value = strings.Join(values, ", ")
 
 	mcs.Facts = append(mcs.Facts, fact)
 
@@ -701,21 +602,16 @@ func (mcs *MessageCardSection) AddFactFromKeyValue(key string, values ...string)
 	return nil
 }
 
-// AddPotentialAction adds one or many MessageCardPotentialAction values to a
-// PotentialActions collection on a MessageCardSection. This is separate from
+// AddPotentialAction adds one or many PotentialAction values to a
+// PotentialActions collection on a Section. This is separate from
 // the actions collection for the MessageCard.
-//
-// Deprecated: use (messagecard.Section).AddPotentialAction
-// instead.
-func (mcs *MessageCardSection) AddPotentialAction(actions ...*MessageCardPotentialAction) error {
+func (mcs *Section) AddPotentialAction(actions ...*PotentialAction) error {
 	return addPotentialAction(&mcs.PotentialActions, actions...)
 }
 
 // AddImage adds an image to a MessageCard section. These images are used to
 // provide a photo gallery inside a MessageCard section.
-//
-// Deprecated: use (messagecard.Section).AddImage instead.
-func (mcs *MessageCardSection) AddImage(sectionImage ...MessageCardSectionImage) error {
+func (mcs *Section) AddImage(sectionImage ...SectionImage) error {
 	for i := range sectionImage {
 		if sectionImage[i].Image == "" {
 			return fmt.Errorf("cannot add empty image URL")
@@ -734,9 +630,7 @@ func (mcs *MessageCardSection) AddImage(sectionImage ...MessageCardSectionImage)
 // AddHeroImageStr adds a Hero Image to a MessageCard section using string
 // arguments. This image is used as the centerpiece or banner of a message
 // card.
-//
-// Deprecated: use (messagecard.Section).AddHeroImageStr instead.
-func (mcs *MessageCardSection) AddHeroImageStr(imageURL string, imageTitle string) error {
+func (mcs *Section) AddHeroImageStr(imageURL string, imageTitle string) error {
 	if imageURL == "" {
 		return fmt.Errorf("cannot add empty hero image URL")
 	}
@@ -745,14 +639,10 @@ func (mcs *MessageCardSection) AddHeroImageStr(imageURL string, imageTitle strin
 		return fmt.Errorf("cannot add empty hero image title")
 	}
 
-	heroImage := MessageCardSectionImage{
+	heroImage := SectionImage{
 		Image: imageURL,
 		Title: imageTitle,
 	}
-	// TODO: Explicitly define or use constructor?
-	// heroImage := NewMessageCardSectionImage()
-	// heroImage.Image = imageURL
-	// heroImage.Title = imageTitle
 
 	mcs.HeroImage = &heroImage
 
@@ -761,11 +651,9 @@ func (mcs *MessageCardSection) AddHeroImageStr(imageURL string, imageTitle strin
 }
 
 // AddHeroImage adds a Hero Image to a MessageCard section using a
-// MessageCardSectionImage argument. This image is used as the centerpiece or
+// SectionImage argument. This image is used as the centerpiece or
 // banner of a message card.
-//
-// Deprecated: use (messagecard.Section).AddHeroImage instead.
-func (mcs *MessageCardSection) AddHeroImage(heroImage MessageCardSectionImage) error {
+func (mcs *Section) AddHeroImage(heroImage SectionImage) error {
 	if heroImage.Image == "" {
 		return fmt.Errorf("cannot add empty hero image URL")
 	}
@@ -780,54 +668,40 @@ func (mcs *MessageCardSection) AddHeroImage(heroImage MessageCardSectionImage) e
 	return nil
 }
 
-// NewMessageCard creates a new message card with fields required by the
-// legacy message card format already predefined.
+// NewMessageCard creates a new legacy MessageCard with required fields
+// predefined.
 //
-// Deprecated: use messagecard.NewMessageCard instead.
-func NewMessageCard() MessageCard {
-	// define expected values to meet Office 365 Connector card requirements
-	// https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#card-fields
-	msgCard := MessageCard{
+// https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#card-fields
+func NewMessageCard() *MessageCard {
+	return &MessageCard{
 		Type:    "MessageCard",
 		Context: "https://schema.org/extensions",
 	}
-
-	return msgCard
 }
 
-// NewMessageCardSection creates an empty message card section.
-//
-// Deprecated: use messagecard.NewMessageCardSection instead.
-func NewMessageCardSection() *MessageCardSection {
-	msgCardSection := MessageCardSection{}
+// NewSection creates an empty message card section
+func NewSection() *Section {
+	msgCardSection := Section{}
 	return &msgCardSection
 }
 
-// NewMessageCardSectionFact creates an empty message card section fact.
-//
-// Deprecated: use messagecard.NewMessageCardSectionFact instead.
-func NewMessageCardSectionFact() MessageCardSectionFact {
-	msgCardSectionFact := MessageCardSectionFact{}
-	return msgCardSectionFact
+// NewSectionFact creates an empty message card section fact
+func NewSectionFact() *SectionFact {
+	return &SectionFact{}
 }
 
-// NewMessageCardSectionImage creates an empty image for use with message card
-// section.
-//
-// Deprecated: use messagecard.NewMessageCardSectionImage instead.
-func NewMessageCardSectionImage() MessageCardSectionImage {
-	msgCardSectionImage := MessageCardSectionImage{}
-	return msgCardSectionImage
+// NewSectionImage creates an empty image for use with message card
+// section
+func NewSectionImage() *SectionImage {
+	return &SectionImage{}
 }
 
-// NewMessageCardPotentialAction creates a new MessageCardPotentialAction
+// NewPotentialAction creates a new PotentialAction
 // using the provided potential action type and name. The name values defines
 // the text that will be displayed on screen for the action. An error is
 // returned if invalid values are supplied.
-//
-// Deprecated: use messagecard.NewMessageCardPotentialAction instead.
-func NewMessageCardPotentialAction(potentialActionType string, name string) (*MessageCardPotentialAction, error) {
-	pa := MessageCardPotentialAction{
+func NewPotentialAction(potentialActionType string, name string) (*PotentialAction, error) {
+	pa := PotentialAction{
 		Type: potentialActionType,
 		Name: name,
 	}

--- a/vendor/github.com/atc0005/go-teams-notify/v2/send.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/send.go
@@ -9,11 +9,10 @@
 package goteamsnotify
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -92,19 +91,66 @@ var ErrWebhookURLUnexpectedPrefix = ErrWebhookURLUnexpected
 // unsuccessful.
 var ErrInvalidWebhookURLResponseText = errors.New("invalid webhook URL response text")
 
-// API - interface of MS Teams notify
+// API is the legacy interface representing a client used to submit messages
+// to a Microsoft Teams channel.
 type API interface {
 	Send(webhookURL string, webhookMessage MessageCard) error
 	SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error
 	SendWithRetry(ctx context.Context, webhookURL string, webhookMessage MessageCard, retries int, retriesDelay int) error
-	SetHTTPClient(httpClient *http.Client) API
-	SetUserAgent(userAgent string) API
 	SkipWebhookURLValidationOnSend(skip bool) API
 	AddWebhookURLValidationPatterns(patterns ...string) API
 	ValidateWebhook(webhookURL string) error
 }
 
+// MessageSender describes the behavior of a baseline Microsoft Teams client.
+//
+// An unexported method is used to prevent client code from implementing this
+// interface in order to support future changes (and not violate backwards
+// compatibility).
+type MessageSender interface {
+	// validateInput(message MessageValidator, webhookURL string) error
+	HTTPClient() *http.Client
+	UserAgent() string
+	ValidateWebhook(webhookURL string) error
+
+	// A private method to prevent client code from implementing the interface
+	// so that any future changes to it will not violate backwards
+	// compatibility.
+	private()
+}
+
+// messagePreparer is a message type that supports marshaling its fields
+// as preparation for delivery to an endpoint.
+type messagePreparer interface {
+	Prepare(recreate bool) error
+}
+
+// messageValidator is a message type that provides validation of its format.
+type messageValidator interface {
+	Validate() error
+}
+
+// teamsMessage is the interface shared by all supported message formats for
+// submission to a Microsoft Teams channel.
+type teamsMessage interface {
+	messagePreparer
+	messageValidator
+
+	Payload() io.Reader
+}
+
+// teamsClient is the legacy client used for submitting messages to a
+// Microsoft Teams channel.
 type teamsClient struct {
+	httpClient                   *http.Client
+	userAgent                    string
+	webhookURLValidationPatterns []string
+	skipWebhookURLValidation     bool
+}
+
+// TeamsClient provides functionality for submitting messages to a Microsoft
+// Teams channel.
+type TeamsClient struct {
 	httpClient                   *http.Client
 	userAgent                    string
 	webhookURLValidationPatterns []string
@@ -133,6 +179,8 @@ func DisableLogging() {
 }
 
 // NewClient - create a brand new client for MS Teams notify
+//
+// Deprecated: use NewTeamsClient() function instead.
 func NewClient() API {
 	client := teamsClient{
 		httpClient: &http.Client{
@@ -144,9 +192,30 @@ func NewClient() API {
 	return &client
 }
 
+// NewTeamsClient constructs a minimal client for submitting messages to a
+// Microsoft Teams channel.
+func NewTeamsClient() *TeamsClient {
+	client := TeamsClient{
+		httpClient: &http.Client{
+			// We're using a context instead of setting this directly
+			// Timeout: DefaultWebhookSendTimeout,
+		},
+		skipWebhookURLValidation: false,
+	}
+	return &client
+}
+
+// private prevents client code from implementing the MessageSender interface
+// so that any future changes to it will not violate backwards compatibility.
+func (c *teamsClient) private() {}
+
+// private prevents client code from implementing the MessageSender interface
+// so that any future changes to it will not violate backwards compatibility.
+func (c *TeamsClient) private() {}
+
 // SetHTTPClient accepts a custom http.Client value which replaces the
 // existing default http.Client.
-func (c *teamsClient) SetHTTPClient(httpClient *http.Client) API {
+func (c *TeamsClient) SetHTTPClient(httpClient *http.Client) *TeamsClient {
 	c.httpClient = httpClient
 
 	return c
@@ -154,92 +223,161 @@ func (c *teamsClient) SetHTTPClient(httpClient *http.Client) API {
 
 // SetUserAgent accepts a custom user agent string. This custom user agent is
 // used when submitting messages to Microsoft Teams.
-func (c *teamsClient) SetUserAgent(userAgent string) API {
+func (c *TeamsClient) SetUserAgent(userAgent string) *TeamsClient {
 	c.userAgent = userAgent
 
 	return c
 }
 
+// UserAgent returns the configured user agent string for the client. If a
+// custom value is not set the default package user agent is returned.
+//
+// Deprecated: use TeamsClient.UserAgent() method instead.
+func (c *teamsClient) UserAgent() string {
+	switch {
+	case c.userAgent != "":
+		return c.userAgent
+	default:
+		return DefaultUserAgent
+	}
+}
+
+// UserAgent returns the configured user agent string for the client. If a
+// custom value is not set the default package user agent is returned.
+func (c *TeamsClient) UserAgent() string {
+	switch {
+	case c.userAgent != "":
+		return c.userAgent
+	default:
+		return DefaultUserAgent
+	}
+}
+
+// AddWebhookURLValidationPatterns collects given patterns for validation of
+// the webhook URL.
+//
+// Deprecated: use TeamsClient.AddWebhookURLValidationPatterns() method instead.
 func (c *teamsClient) AddWebhookURLValidationPatterns(patterns ...string) API {
 	c.webhookURLValidationPatterns = append(c.webhookURLValidationPatterns, patterns...)
 	return c
 }
 
+// AddWebhookURLValidationPatterns collects given patterns for validation of
+// the webhook URL.
+func (c *TeamsClient) AddWebhookURLValidationPatterns(patterns ...string) *TeamsClient {
+	c.webhookURLValidationPatterns = append(c.webhookURLValidationPatterns, patterns...)
+	return c
+}
+
+// HTTPClient returns the internal pointer to an http.Client. This can be used
+// to further modify specific http.Client field values.
+//
+// Deprecated: use TeamsClient.HTTPClient() method instead.
+func (c *teamsClient) HTTPClient() *http.Client {
+	return c.httpClient
+}
+
+// HTTPClient returns the internal pointer to an http.Client. This can be used
+// to further modify specific http.Client field values.
+func (c *TeamsClient) HTTPClient() *http.Client {
+	return c.httpClient
+}
+
 // Send is a wrapper function around the SendWithContext method in order to
 // provide backwards compatibility.
-func (c teamsClient) Send(webhookURL string, webhookMessage MessageCard) error {
+//
+// Deprecated: use TeamsClient.Send() method instead.
+func (c *teamsClient) Send(webhookURL string, webhookMessage MessageCard) error {
 	// Create context that can be used to emulate existing timeout behavior.
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultWebhookSendTimeout)
 	defer cancel()
 
-	return c.SendWithContext(ctx, webhookURL, webhookMessage)
+	return sendWithContext(ctx, c, webhookURL, &webhookMessage)
 }
 
-// SendWithContext posts a notification to the provided MS Teams webhook URL.
-// The http client request honors the cancellation or timeout of the provided
-// context.
-func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error {
-	logger.Printf("SendWithContext: Webhook message received: %#v\n", webhookMessage)
+// Send is a wrapper function around the SendWithContext method in order to
+// provide backwards compatibility.
+func (c *TeamsClient) Send(webhookURL string, message teamsMessage) error {
+	// Create context that can be used to emulate existing timeout behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultWebhookSendTimeout)
+	defer cancel()
 
-	// optionally skip webhook validation
-	if c.skipWebhookURLValidation {
-		logger.Printf("SendWithContext: Webhook URL will not be validated: %#v\n", webhookURL)
-	}
+	return sendWithContext(ctx, c, webhookURL, message)
+}
 
-	// Validate input data
-	if err := c.validateInput(webhookMessage, webhookURL); err != nil {
-		return err
-	}
+// SendWithContext submits a given message to a Microsoft Teams channel using
+// the provided webhook URL. The http client request honors the cancellation
+// or timeout of the provided context.
+//
+// Deprecated: use TeamsClient.SendWithContext() method instead.
+func (c *teamsClient) SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error {
+	return sendWithContext(ctx, c, webhookURL, &webhookMessage)
+}
 
-	// prepare message
-	webhookMessageByte, _ := json.Marshal(webhookMessage)
-	webhookMessageBuffer := bytes.NewBuffer(webhookMessageByte)
+// SendWithContext submits a given message to a Microsoft Teams channel using
+// the provided webhook URL. The http client request honors the cancellation
+// or timeout of the provided context.
+func (c *TeamsClient) SendWithContext(ctx context.Context, webhookURL string, message teamsMessage) error {
+	return sendWithContext(ctx, c, webhookURL, message)
+}
 
-	// Basic, unformatted JSON
-	// logger.Printf("SendWithContext: %+v\n", string(webhookMessageByte))
+// SendWithRetry provides message retry support when submitting messages to a
+// Microsoft Teams channel. The caller is responsible for providing the
+// desired context timeout, the number of retries and retries delay.
+//
+// Deprecated: use TeamsClient.SendWithRetry() method instead.
+func (c *teamsClient) SendWithRetry(ctx context.Context, webhookURL string, webhookMessage MessageCard, retries int, retriesDelay int) error {
+	return sendWithRetry(ctx, c, webhookURL, &webhookMessage, retries, retriesDelay)
+}
 
-	var prettyJSON bytes.Buffer
-	if err := json.Indent(&prettyJSON, webhookMessageByte, "", "\t"); err != nil {
-		return err
-	}
-	logger.Printf("SendWithContext: Payload for Microsoft Teams: \n\n%v\n\n", prettyJSON.String())
+// SendWithRetry provides message retry support when submitting messages to a
+// Microsoft Teams channel. The caller is responsible for providing the
+// desired context timeout, the number of retries and retries delay.
+func (c *TeamsClient) SendWithRetry(ctx context.Context, webhookURL string, message teamsMessage, retries int, retriesDelay int) error {
+	return sendWithRetry(ctx, c, webhookURL, message, retries, retriesDelay)
+}
 
-	// prepare request (error not possible)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, webhookMessageBuffer)
-	req.Header.Add("Content-Type", "application/json;charset=utf-8")
+// SkipWebhookURLValidationOnSend allows the caller to optionally disable
+// webhook URL validation.
+//
+// Deprecated: use TeamsClient.SkipWebhookURLValidationOnSend() method instead.
+func (c *teamsClient) SkipWebhookURLValidationOnSend(skip bool) API {
+	c.skipWebhookURLValidation = skip
+	return c
+}
 
-	// If provided, override the project-specific user agent with custom value.
-	switch {
-	case c.userAgent != "":
-		req.Header.Set("User-Agent", c.userAgent)
-	default:
-		req.Header.Set("User-Agent", DefaultUserAgent)
-	}
+// SkipWebhookURLValidationOnSend allows the caller to optionally disable
+// webhook URL validation.
+func (c *TeamsClient) SkipWebhookURLValidationOnSend(skip bool) *TeamsClient {
+	c.skipWebhookURLValidation = skip
+	return c
+}
 
-	// do the request
-	res, err := c.httpClient.Do(req)
+// prepareRequest is a helper function that prepares a http.Request (including
+// all desired headers) in order to submit a given prepared message to an
+// endpoint.
+func prepareRequest(ctx context.Context, userAgent string, webhookURL string, preparedMessage io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, preparedMessage)
 	if err != nil {
-		logger.Println(err)
-		return err
+		return nil, err
 	}
 
-	if ctx.Err() != nil {
-		logger.Println("SendWithContext: Context has expired after Do(req):", time.Now().Format("15:04:05"))
-	}
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
+	req.Header.Set("User-Agent", userAgent)
 
-	// Make sure that we close the response body once we're done with it
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			log.Printf("error closing response body: %v", err)
-		}
-	}()
+	return req, nil
+}
 
+// processResponse is a helper function responsible for validating a response
+// from an endpoint after submitting a message.
+func processResponse(response *http.Response) (string, error) {
 	// Get the response body, then convert to string for use with extended
 	// error messages
-	responseData, err := ioutil.ReadAll(res.Body)
+	responseData, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		logger.Println(err)
-		return err
+
+		return "", err
 	}
 	responseString := string(responseData)
 
@@ -249,10 +387,12 @@ func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, web
 	// top level MessageCard Summary or Text field, the remote API returns
 	// "Summary or Text is required." as a text string. We include that
 	// response text in the error message that we return to the caller.
-	case res.StatusCode >= 299:
-		err = fmt.Errorf("error on notification: %v, %q", res.Status, responseString)
+	case response.StatusCode >= 299:
+		err = fmt.Errorf("error on notification: %v, %q", response.Status, responseString)
+
 		logger.Println(err)
-		return err
+
+		return "", err
 
 	// Microsoft Teams developers have indicated that a 200 status code is
 	// insufficient to confirm that a message was successfully submitted.
@@ -263,7 +403,6 @@ func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, web
 	//
 	// See atc0005/go-teams-notify#59 for more information.
 	case responseString != strings.TrimSpace(ExpectedWebhookURLResponseText):
-
 		err = fmt.Errorf(
 			"got %q, expected %q: %w",
 			responseString,
@@ -272,110 +411,19 @@ func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, web
 		)
 
 		logger.Println(err)
-		return err
+
+		return "", err
 
 	default:
-
-		// log the response string
-		logger.Printf("SendWithContext: Response string from Microsoft Teams API: %v\n", responseString)
-
-		return nil
+		return responseString, nil
 	}
 }
 
-// SendWithRetry is a wrapper function around the SendWithContext method in
-// order to provide message retry support. The caller is responsible for
-// provided the desired context timeout, the number of retries and retries
-// delay.
-func (c teamsClient) SendWithRetry(ctx context.Context, webhookURL string, webhookMessage MessageCard, retries int, retriesDelay int) error {
-	var result error
+// validateWebhook applies webhook URL validation unless explicitly disabled.
+func validateWebhook(webhookURL string, skipWebhookValidation bool, patterns []string) error {
+	if skipWebhookValidation || webhookURL == DisableWebhookURLValidation {
+		logger.Printf("validateWebhook: Webhook URL will not be validated: %#v\n", webhookURL)
 
-	// initial attempt + number of specified retries
-	attemptsAllowed := 1 + retries
-
-	// attempt to send message to Microsoft Teams, retry specified number of
-	// times before giving up
-	for attempt := 1; attempt <= attemptsAllowed; attempt++ {
-		// the result from the last attempt is returned to the caller
-		result = c.SendWithContext(ctx, webhookURL, webhookMessage)
-
-		switch {
-		case result == nil:
-
-			logger.Printf(
-				"SendWithRetry: successfully sent message after %d of %d attempts\n",
-				attempt,
-				attemptsAllowed,
-			)
-
-			// No further retries needed
-			return nil
-
-		// While the context is passed to mstClient.SendWithContext and it
-		// should ensure that it is respected, we check here explicitly in
-		// order to return early in an effort to prevent undesired message
-		// attempts
-		case ctx.Err() != nil && result != nil:
-
-			errMsg := fmt.Errorf(
-				"SendWithRetry: context cancelled or expired: %v; "+
-					"aborting message submission after %d of %d attempts: %w",
-				ctx.Err().Error(),
-				attempt,
-				attemptsAllowed,
-				result,
-			)
-
-			logger.Println(errMsg)
-			return errMsg
-
-		// Last send attempt failed. Context hasn't expired yet and at least
-		// one retry attempt remains.
-		default:
-
-			ourRetryDelay := time.Duration(retriesDelay) * time.Second
-
-			logger.Printf(
-				"SendWithRetry: Attempt %d of %d to send message failed: %v",
-				attempt,
-				attemptsAllowed,
-				result,
-			)
-
-			// apply retry delay since our context hasn't been cancelled yet,
-			// otherwise continue with the loop to allow context cancellation
-			// handling logic to be applied
-			logger.Printf(
-				"SendWithRetry: Context not cancelled yet, applying retry delay of %v",
-				ourRetryDelay,
-			)
-			time.Sleep(ourRetryDelay)
-		}
-	}
-
-	return result
-}
-
-// SkipWebhookURLValidationOnSend allows the caller to optionally disable
-// webhook URL validation.
-func (c *teamsClient) SkipWebhookURLValidationOnSend(skip bool) API {
-	c.skipWebhookURLValidation = skip
-	return c
-}
-
-// validateInput verifies if the input parameters are valid
-func (c teamsClient) validateInput(webhookMessage MessageCard, webhookURL string) error {
-	// validate url
-	if err := c.ValidateWebhook(webhookURL); err != nil {
-		return err
-	}
-
-	// validate message
-	return webhookMessage.Validate()
-}
-
-func (c teamsClient) ValidateWebhook(webhookURL string) error {
-	if c.skipWebhookURLValidation || webhookURL == DisableWebhookURLValidation {
 		return nil
 	}
 
@@ -384,12 +432,11 @@ func (c teamsClient) ValidateWebhook(webhookURL string) error {
 		return fmt.Errorf("unable to parse webhook URL %q: %w", webhookURL, err)
 	}
 
-	patterns := c.webhookURLValidationPatterns
 	if len(patterns) == 0 {
 		patterns = []string{DefaultWebhookURLValidationPattern}
 	}
 
-	// Return true if at least one pattern matches
+	// Indicate passing validation if at least one pattern matches.
 	for _, pat := range patterns {
 		matched, err := regexp.MatchString(pat, webhookURL)
 		if err != nil {
@@ -400,7 +447,151 @@ func (c teamsClient) ValidateWebhook(webhookURL string) error {
 		}
 	}
 
-	return fmt.Errorf("%w; got: %q, patterns: %s", ErrWebhookURLUnexpected, u.String(), strings.Join(patterns, ","))
+	return fmt.Errorf(
+		"%w; got: %q, patterns: %s",
+		ErrWebhookURLUnexpected,
+		u.String(),
+		strings.Join(patterns, ","),
+	)
+}
+
+// ValidateWebhook applies webhook URL validation unless explicitly disabled.
+//
+// Deprecated: use TeamsClient.ValidateWebhook() method instead.
+func (c *teamsClient) ValidateWebhook(webhookURL string) error {
+	return validateWebhook(webhookURL, c.skipWebhookURLValidation, c.webhookURLValidationPatterns)
+}
+
+// ValidateWebhook applies webhook URL validation unless explicitly disabled.
+func (c *TeamsClient) ValidateWebhook(webhookURL string) error {
+	return validateWebhook(webhookURL, c.skipWebhookURLValidation, c.webhookURLValidationPatterns)
+}
+
+// sendWithContext submits a given message to a Microsoft Teams channel using
+// the provided webhook URL and client. The http client request honors the
+// cancellation or timeout of the provided context.
+func sendWithContext(ctx context.Context, client MessageSender, webhookURL string, message teamsMessage) error {
+	logger.Printf("sendWithContext: Webhook message received: %#v\n", message)
+
+	if err := client.ValidateWebhook(webhookURL); err != nil {
+		return fmt.Errorf(
+			"failed to validate webhook URL: %w",
+			err,
+		)
+	}
+
+	if err := message.Validate(); err != nil {
+		return fmt.Errorf(
+			"failed to validate message: %w",
+			err,
+		)
+	}
+
+	if err := message.Prepare(false); err != nil {
+		return fmt.Errorf(
+			"failed to prepare message: %w",
+			err,
+		)
+	}
+
+	req, err := prepareRequest(ctx, client.UserAgent(), webhookURL, message.Payload())
+	if err != nil {
+		return fmt.Errorf(
+			"failed to prepare request: %w",
+			err,
+		)
+	}
+
+	// Submit message to endpoint.
+	res, err := client.HTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to submit message: %w",
+			err,
+		)
+	}
+
+	// Make sure that we close the response body once we're done with it
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
+
+	responseText, err := processResponse(res)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to process response: %w",
+			err,
+		)
+	}
+
+	logger.Printf("sendWithContext: Response string from Microsoft Teams API: %v\n", responseText)
+
+	return nil
+}
+
+// sendWithRetry provides message retry support when submitting messages to a
+// Microsoft Teams channel. The caller is responsible for providing the
+// desired context timeout, the number of retries and retries delay.
+func sendWithRetry(ctx context.Context, client MessageSender, webhookURL string, message teamsMessage, retries int, retriesDelay int) error {
+	var result error
+
+	// initial attempt + number of specified retries
+	attemptsAllowed := 1 + retries
+
+	// attempt to send message to Microsoft Teams, retry specified number of
+	// times before giving up
+	for attempt := 1; attempt <= attemptsAllowed; attempt++ {
+		// the result from the last attempt is returned to the caller
+		result = sendWithContext(ctx, client, webhookURL, message)
+
+		switch {
+		case result != nil:
+
+			logger.Printf(
+				"sendWithRetry: Attempt %d of %d to send message failed: %v",
+				attempt,
+				attemptsAllowed,
+				result,
+			)
+
+			if ctx.Err() != nil {
+				errMsg := fmt.Errorf(
+					"sendWithRetry: context cancelled or expired: %v; "+
+						"aborting message submission after %d of %d attempts: %w",
+					ctx.Err().Error(),
+					attempt,
+					attemptsAllowed,
+					result,
+				)
+
+				logger.Println(errMsg)
+
+				return errMsg
+			}
+
+			ourRetryDelay := time.Duration(retriesDelay) * time.Second
+
+			logger.Printf(
+				"sendWithRetry: Context not cancelled yet, applying retry delay of %v",
+				ourRetryDelay,
+			)
+			time.Sleep(ourRetryDelay)
+
+		default:
+			logger.Printf(
+				"sendWithRetry: successfully sent message after %d of %d attempts\n",
+				attempt,
+				attemptsAllowed,
+			)
+
+			// No further retries needed
+			return nil
+		}
+	}
+
+	return result
 }
 
 // old deprecated helper functions --------------------------------------------------------------------------------------------------------------

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,7 @@
-# github.com/atc0005/go-teams-notify/v2 v2.6.1-0.20220208130324-89aca42adbdd
+# github.com/atc0005/go-teams-notify/v2 v2.7.0-alpha.1
 ## explicit; go 1.14
 github.com/atc0005/go-teams-notify/v2
+github.com/atc0005/go-teams-notify/v2/botapi
+github.com/atc0005/go-teams-notify/v2/messagecard
 # github.com/davecgh/go-spew v1.1.1
 ## explicit


### PR DESCRIPTION
Initial support for user mentions is provided
by way of new alpha release of `atc0005/go-teams-notify`
library. Due to limitations of the library, user mentions
are not compatible with specific existing features:

- message title
- URL "buttons"
- message border coloring

Future support for user mentions is expected to provide
most (or perhaps all) of this functionality.

README has been updated to provide an example of the new
user mention functionality.

fixes GH-197