### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -6,37 +6,33 @@
 // full license information.
 
 /*
-
 send2teams is a small CLI tool used to submit messages to Microsoft Teams.
 
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/send2teams) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 send2teams is intended for use by Nagios, scripts or other actions that may
 need to submit pass/fail results to a MS Teams channel.
 
-FEATURES
+# FEATURES
 
-• single binary, no outside dependencies
+- single binary, no outside dependencies
+  - minimal configuration
+  - very few build dependencies
+  - optional conversion of messages with Windows, Mac or Linux newlines to
+    `<br>` to increase compatibility with Teams formatting
+  - message delivery retry support with retry and retry delay values
+    configurable via flag
+  - optional support for specifying url/description pairs for display in
+    Microsoft Teams messages
 
-• minimal configuration
-
-• very few build dependencies
-
-• optional conversion of messages with Windows, Mac or Linux newlines to `<br>` to increase compatibility with Teams formatting
-
-• message delivery retry support with retry and retry delay values configurable via flag
-
-• optional support for specifying url/description pairs for display in Microsoft Teams messages
-
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -6,9 +6,7 @@
 // full license information.
 
 /*
-
 Package config provides types and functions to collect, validate and apply
 user-provided settings.
-
 */
 package config


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.