### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/send2teams/doc.go
+++ b/cmd/send2teams/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/send2teams
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Small CLI tool used to submit messages to Microsoft Teams. send2teams is
+// intended for use by Nagios, scripts or other actions that may need to
+// submit pass/fail results to a MS Teams channel.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/send2teams
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive package-comment linting error
surfaced by recent linter update.