### PR TITLE
Update .gitignore to exclude Windows syso files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 /send2teams
 /send2teams.exe
 
+# Ignore go generate produced Windows executable resource files
+*.syso
+


### PR DESCRIPTION
These files are produced when running go generate
as part of the build process and should not be
retained in version control.

refs GH-274