### PR TITLE
Fix CHANGELOG summary for v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ The following types of changes will be recorded in this file:
 - Build improvements
 - built using Go 1.19.6
   - Statically linked
-  - Linux x64
+  - Windows (x86, x64)
+  - Linux (x86, x64)
 
 ### Added
 


### PR DESCRIPTION
The v0.11.0 release summary incorrectly stated that only Linux x64 binaries were provided.