### PR TITLE
Update atc0005/go-teams-notify to v2.7.1-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,4 @@ go 1.19
 //
 // replace github.com/atc0005/go-teams-notify/v2 => ../go-teams-notify
 
-require github.com/atc0005/go-teams-notify/v2 v2.7.0
+require github.com/atc0005/go-teams-notify/v2 v2.7.1-rc.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify/v2 v2.7.0 h1:yRKblRTM/v+FnbibPAQiBcgT+aUBn/8zj9E/UxBdIRg=
-github.com/atc0005/go-teams-notify/v2 v2.7.0/go.mod h1:nJeYAr8U1KtT376MUHHiy47nqy/4Mn0UR8veVQxdMcM=
+github.com/atc0005/go-teams-notify/v2 v2.7.1-rc.1 h1:3/WuS2AExIvhUCrzednq7kuJ5TsW5Ae/aIRqxLfAmsQ=
+github.com/atc0005/go-teams-notify/v2 v2.7.1-rc.1/go.mod h1:wm/+j2d5u6Rg0BeAwp1T5YXhEhf3uRMZAEwP6ZY6TRg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,8 +10,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
@@ -26,6 +26,26 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v2.7.1] - 2023-03-21
+
+### Changed
+
+- Dependencies
+  - `github.com/stretchr/testify`
+    - `v1.8.1` to `v1.8.2`
+- CI
+  - (GH-198) Add Go Module Validation, Dependency Updates jobs
+  - (GH-200) Drop `Push Validation` workflow
+  - (GH-201) Rework workflow scheduling
+  - (GH-203) Remove `Push Validation` workflow status badge
+  - (GH-207) Update vuln analysis GHAW to use on.push hook
+- `Adaptive Card` format
+  - (GH-206) Update `AdaptiveCardMaxVersion` to 1.5
+
+### Fixed
+
+- (GH-208) Validation of `(adaptivecard.Attachment).Content` is missing
+
 ## [v2.7.0] - 2022-12-12
 
 ### Added
@@ -443,7 +463,8 @@ The following types of changes will be recorded in this file:
 
 - add initial functionality of sending messages to MS Teams channel
 
-[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.7.0...HEAD
+[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.7.1...HEAD
+[v2.7.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.7.1
 [v2.7.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.7.0
 [v2.6.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.6.1
 [v2.6.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.6.0

--- a/vendor/github.com/atc0005/go-teams-notify/v2/README.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/README.md
@@ -9,7 +9,6 @@ A package to send messages to a Microsoft Teams channel.
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/atc0005/go-teams-notify)](https://github.com/atc0005/go-teams-notify)
 [![Lint and Build](https://github.com/atc0005/go-teams-notify/actions/workflows/lint-and-build.yml/badge.svg)](https://github.com/atc0005/go-teams-notify/actions/workflows/lint-and-build.yml)
 [![Project Analysis](https://github.com/atc0005/go-teams-notify/actions/workflows/project-analysis.yml/badge.svg)](https://github.com/atc0005/go-teams-notify/actions/workflows/project-analysis.yml)
-[![Push Validation](https://github.com/atc0005/go-teams-notify/actions/workflows/push-validation.yml/badge.svg)](https://github.com/atc0005/go-teams-notify/actions/workflows/push-validation.yml)
 
 <!-- omit in toc -->
 ## Table of contents

--- a/vendor/github.com/atc0005/go-teams-notify/v2/adaptivecard/adaptivecard.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/adaptivecard/adaptivecard.go
@@ -39,28 +39,9 @@ const (
 	// AdaptiveCardMaxVersion represents the highest supported version of the
 	// Adaptive Card schema supported in Microsoft Teams messages.
 	//
-	// Version 1.3 is the highest supported for user-generated cards.
 	// https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#support-for-adaptive-cards
 	// https://adaptivecards.io/designer
-	//
-	// Version 1.4 is when Action.Execute was introduced.
-	//
-	// Per this doc:
-	// https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#support-for-adaptive-cards
-	//
-	// the "Action.Execute" action is supported:
-	//
-	// "For Adaptive Cards in Incoming Webhooks, all native Adaptive Card
-	// schema elements, except Action.Submit, are fully supported. The
-	// supported actions are Action.OpenURL, Action.ShowCard,
-	// Action.ToggleVisibility, and Action.Execute."
-	//
-	// Per this doc, Teams MAY support the Action.Execute action:
-	//
-	// https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/universal-action-model#schema
-	//
-	// AdaptiveCardMaxVersion  float64 = 1.4
-	AdaptiveCardMaxVersion  float64 = 1.3
+	AdaptiveCardMaxVersion  float64 = 1.5
 	AdaptiveCardMinVersion  float64 = 1.0
 	AdaptiveCardVersionTmpl string  = "%0.1f"
 )
@@ -932,6 +913,8 @@ func (a Attachment) Validate() error {
 		"attachment",
 		ErrInvalidType,
 	)
+
+	v.SelfValidate(a.Content)
 
 	return v.Err()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/atc0005/go-teams-notify/v2 v2.7.0
+# github.com/atc0005/go-teams-notify/v2 v2.7.1-rc.1
 ## explicit; go 1.14
 github.com/atc0005/go-teams-notify/v2
 github.com/atc0005/go-teams-notify/v2/adaptivecard


### PR DESCRIPTION
Update dependency to the latest version (bug fixes).