### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ const (
 	retriesDelayFlagHelp                = "The number of seconds that this application will wait before making another delivery attempt."
 )
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Default flag settings if not overridden by user input
 const (
 	defaultMessageThemeColor           string = "NotUsed"

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -31,7 +31,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.IntVar(&c.Retries, "retries", defaultRetries, retriesFlagHelp)
 	flag.IntVar(&c.RetriesDelay, "retries-delay", defaultRetriesDelay, retriesDelayFlagHelp)
 	flag.BoolVar(&c.ShowVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
-	flag.BoolVar(&c.ShowVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.ShowVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+shorthandFlagSuffix)
 
 	flag.Usage = flagsUsage()
 


### PR DESCRIPTION
Replace literal text with new `shorthandFlagSuffix` config constant.