### PR TITLE
Fix Teams submission timeout value logic

### DIFF
--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -15,10 +15,15 @@ import (
 // TeamsSubmissionTimeout is the timeout value for sending messages to
 // Microsoft Teams.
 func (c Config) TeamsSubmissionTimeout() time.Duration {
+	delay := time.Duration(c.Retries) * time.Duration(c.RetriesDelay)
 
-	return time.Duration(c.Retries) *
-		time.Duration(c.RetriesDelay) *
-		teamsSubmissionTimeoutMultiplier
+	// Fallback to 1 if retry behavior was disabled or retry delay is set too
+	// short.
+	if delay <= 0 {
+		delay = time.Duration(1)
+	}
+
+	return delay * teamsSubmissionTimeoutMultiplier
 }
 
 // UserAgent returns a string usable as-is as a custom user agent for plugins


### PR DESCRIPTION
Fallback to using a value of 1 during calculations when applying the timeout multiplier if retry behavior was disabled or if the retry delay is set too short.

refs GH-524