### PR TITLE
Remove automatic display of help text on err

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -477,7 +477,6 @@ func NewConfig() (*Config, error) {
 
 	// log.Debug("Validating configuration ...")
 	if err := cfg.Validate(cfg.DisableWebhookURLValidation); err != nil {
-		flag.Usage()
 		return nil, err
 	}
 	// log.Debug("Configuration validated")


### PR DESCRIPTION
Remove usage information when CLI flag validation fails as the error output should be the primary focus; displaying help text and error text together is too noisy to be truly helpful.

If/when needed, the user can use the `-h` or `--help` flags to be reminded of supported flags and values.

refs GH-532