### PR TITLE
Bump `atc0005/go-teams-notify` to v2.12.0-alpha.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,4 @@ go 1.19
 //
 // replace github.com/atc0005/go-teams-notify/v2 => ../go-teams-notify
 
-require github.com/atc0005/go-teams-notify/v2 v2.11.0
+require github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify/v2 v2.11.0 h1:CugCxSm9Z8GG1KDpAxCpJJk1uo1p9p50RMYhbJgKvdc=
-github.com/atc0005/go-teams-notify/v2 v2.11.0/go.mod h1:WSv9moolRsBcpZbwEf6gZxj7h0uJlJskJq5zkEWKO8Y=
+github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1 h1:0km5FZ3RYE3nQn8nnptNJ3DjYIAm1k7+mtoZUByKjJc=
+github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1/go.mod h1:WSv9moolRsBcpZbwEf6gZxj7h0uJlJskJq5zkEWKO8Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
@@ -26,28 +26,6 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
-## [v2.11.0] - 2024-08-02
-
-### Added
-
-- (GH-275) Add initial support for Workflow connectors
-
-### Changed
-
-#### Dependency Updates
-
-- (GH-259) Go Dependency: Bump github.com/stretchr/testify from 1.8.4 to 1.9.0
-
-#### Other
-
-- (GH-272) Documentation refresh for O365 & Workflow connectors
-
-### Fixed
-
-- (GH-261) Remove inactive maligned linter
-- (GH-274) Fix validation for `Action.Type` field
-- (GH-283) Update CodeQL workflow to run on dev branch PRs
-
 ## [v2.10.0] - 2024-02-22
 
 ### Added
@@ -545,8 +523,7 @@ The following types of changes will be recorded in this file:
 
 - add initial functionality of sending messages to MS Teams channel
 
-[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.11.0...HEAD
-[v2.11.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.11.0
+[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.10.0...HEAD
 [v2.10.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.10.0
 [v2.9.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.9.0
 [v2.8.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.8.0

--- a/vendor/github.com/atc0005/go-teams-notify/v2/send.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/send.go
@@ -134,9 +134,9 @@ type messageValidator interface {
 	Validate() error
 }
 
-// teamsMessage is the interface shared by all supported message formats for
+// TeamsMessage is the interface shared by all supported message formats for
 // submission to a Microsoft Teams channel.
-type teamsMessage interface {
+type TeamsMessage interface {
 	messagePreparer
 	messageValidator
 
@@ -301,7 +301,7 @@ func (c *teamsClient) Send(webhookURL string, webhookMessage MessageCard) error 
 
 // Send is a wrapper function around the SendWithContext method in order to
 // provide backwards compatibility.
-func (c *TeamsClient) Send(webhookURL string, message teamsMessage) error {
+func (c *TeamsClient) Send(webhookURL string, message TeamsMessage) error {
 	// Create context that can be used to emulate existing timeout behavior.
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultWebhookSendTimeout)
 	defer cancel()
@@ -321,7 +321,7 @@ func (c *teamsClient) SendWithContext(ctx context.Context, webhookURL string, we
 // SendWithContext submits a given message to a Microsoft Teams channel using
 // the provided webhook URL. The http client request honors the cancellation
 // or timeout of the provided context.
-func (c *TeamsClient) SendWithContext(ctx context.Context, webhookURL string, message teamsMessage) error {
+func (c *TeamsClient) SendWithContext(ctx context.Context, webhookURL string, message TeamsMessage) error {
 	return sendWithContext(ctx, c, webhookURL, message)
 }
 
@@ -337,7 +337,7 @@ func (c *teamsClient) SendWithRetry(ctx context.Context, webhookURL string, webh
 // SendWithRetry provides message retry support when submitting messages to a
 // Microsoft Teams channel. The caller is responsible for providing the
 // desired context timeout, the number of retries and retries delay.
-func (c *TeamsClient) SendWithRetry(ctx context.Context, webhookURL string, message teamsMessage, retries int, retriesDelay int) error {
+func (c *TeamsClient) SendWithRetry(ctx context.Context, webhookURL string, message TeamsMessage, retries int, retriesDelay int) error {
 	return sendWithRetry(ctx, c, webhookURL, message, retries, retriesDelay)
 }
 
@@ -499,7 +499,7 @@ func (c *TeamsClient) ValidateWebhook(webhookURL string) error {
 // sendWithContext submits a given message to a Microsoft Teams channel using
 // the provided webhook URL and client. The http client request honors the
 // cancellation or timeout of the provided context.
-func sendWithContext(ctx context.Context, client MessageSender, webhookURL string, message teamsMessage) error {
+func sendWithContext(ctx context.Context, client MessageSender, webhookURL string, message TeamsMessage) error {
 	logger.Printf("sendWithContext: Webhook message received: %#v\n", message)
 
 	if err := client.ValidateWebhook(webhookURL); err != nil {
@@ -563,7 +563,7 @@ func sendWithContext(ctx context.Context, client MessageSender, webhookURL strin
 // sendWithRetry provides message retry support when submitting messages to a
 // Microsoft Teams channel. The caller is responsible for providing the
 // desired context timeout, the number of retries and retries delay.
-func sendWithRetry(ctx context.Context, client MessageSender, webhookURL string, message teamsMessage, retries int, retriesDelay int) error {
+func sendWithRetry(ctx context.Context, client MessageSender, webhookURL string, message TeamsMessage, retries int, retriesDelay int) error {
 	var result error
 
 	// initial attempt + number of specified retries

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/atc0005/go-teams-notify/v2 v2.11.0
+# github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1
 ## explicit; go 1.14
 github.com/atc0005/go-teams-notify/v2
 github.com/atc0005/go-teams-notify/v2/adaptivecard


### PR DESCRIPTION
Test latest dependency changes.