### PR TITLE
Bump `atc0005/go-teams-notify` to v2.12.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,4 @@ go 1.19
 //
 // replace github.com/atc0005/go-teams-notify/v2 => ../go-teams-notify
 
-require github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1
+require github.com/atc0005/go-teams-notify/v2 v2.12.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1 h1:0km5FZ3RYE3nQn8nnptNJ3DjYIAm1k7+mtoZUByKjJc=
-github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1/go.mod h1:WSv9moolRsBcpZbwEf6gZxj7h0uJlJskJq5zkEWKO8Y=
+github.com/atc0005/go-teams-notify/v2 v2.12.0-rc.1 h1:offI4U3DKO62bmGDUWrh7/tPTPlweYUm18VqG5v3WMA=
+github.com/atc0005/go-teams-notify/v2 v2.12.0-rc.1/go.mod h1:WSv9moolRsBcpZbwEf6gZxj7h0uJlJskJq5zkEWKO8Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
@@ -26,6 +26,28 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v2.11.0] - 2024-08-02
+
+### Added
+
+- (GH-275) Add initial support for Workflow connectors
+
+### Changed
+
+#### Dependency Updates
+
+- (GH-259) Go Dependency: Bump github.com/stretchr/testify from 1.8.4 to 1.9.0
+
+#### Other
+
+- (GH-272) Documentation refresh for O365 & Workflow connectors
+
+### Fixed
+
+- (GH-261) Remove inactive maligned linter
+- (GH-274) Fix validation for `Action.Type` field
+- (GH-283) Update CodeQL workflow to run on dev branch PRs
+
 ## [v2.10.0] - 2024-02-22
 
 ### Added
@@ -523,7 +545,8 @@ The following types of changes will be recorded in this file:
 
 - add initial functionality of sending messages to MS Teams channel
 
-[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.10.0...HEAD
+[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.11.0...HEAD
+[v2.11.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.11.0
 [v2.10.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.10.0
 [v2.9.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.9.0
 [v2.8.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.8.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/atc0005/go-teams-notify/v2 v2.12.0-alpha.1
+# github.com/atc0005/go-teams-notify/v2 v2.12.0-rc.1
 ## explicit; go 1.14
 github.com/atc0005/go-teams-notify/v2
 github.com/atc0005/go-teams-notify/v2/adaptivecard


### PR DESCRIPTION
Test latest dependency changes.