### PR TITLE
chore: add new workflowURLBaseDomain api.powerplatform.com

### DIFF
--- a/vendor/github.com/atc0005/go-teams-notify/v2/send.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/send.go
@@ -36,7 +36,7 @@ const (
 
 // Known Workflow URL patterns for submitting messages to Microsoft Teams.
 const (
-	WorkflowURLBaseDomain = `^https:\/\/(?:.*)(:?\.azure-api|logic\.azure)\.(?:com|net)`
+	WorkflowURLBaseDomain = `^https:\/\/(?:.*)(:?\.azure-api|logic\.azure|api\.powerplatform)\.(?:com|net)`
 )
 
 // DisableWebhookURLValidation is a special keyword used to indicate to


### PR DESCRIPTION
### Summary

This PR updates the webhook URL validation logic within `send2teams` to natively support the new official Power Platform endpoint domain: `api.powerplatform.com`.

### Why this change?

Microsoft is migrating webhook trigger URLs for Power Automate and Logic Apps workflows (including those used by Teams workflows) from the legacy `logic.azure.com` domain to `api.powerplatform.com`. The deadline for this migration was November 30, 2025.

We have received notifications (example: "The flow '<Name Flow>' uses the request trigger, and its URL was recently changed...") confirming this mandatory domain change.

Since the update, executing `send2teams` (v0.13.11) with the new URLs fails with a validation error, forcing the use of the `-disable-url-validation` flag:

```

webhook URL validation failed: webhook URL does not match one of expected patterns; got: "https://\<...\>[[.api.powerplatform.com:443/](https://www.google.com/search?q=https://.api.powerplatform.com:443/)](https://www.google.com/search?q=https://.api.powerplatform.com:443/)...", patterns: ^https://(?:.*.webhook|outlook).office(?:365)?.com,^https://(?:.*)(:?.azure-api|logic.azure).(?:com|net)
